### PR TITLE
Fix a leak when the xaddr changes

### DIFF
--- a/onvif/client.py
+++ b/onvif/client.py
@@ -422,10 +422,7 @@ class ONVIFCamera:
 
     def create_onvif_service(self, name, port_type=None):
         """Create ONVIF service client"""
-
         name = name.lower()
-        xaddr, wsdl_file, binding_name = self.get_definition(name, port_type)
-
         # Don't re-create bindings if the xaddr remains the same.
         # The xaddr can change when a new PullPointSubscription is created.
         binding_key = (name, port_type)
@@ -445,6 +442,8 @@ class ONVIFCamera:
                 task.add_done_callback(self._background_tasks.remove)
                 self._background_tasks.add(task)
             self.services.pop(binding_key)
+
+        xaddr, wsdl_file, binding_name = self.get_definition(name, port_type)
 
         service = ONVIFService(
             xaddr,

--- a/onvif/client.py
+++ b/onvif/client.py
@@ -442,7 +442,7 @@ class ONVIFCamera:
             else:
                 # Close the existing service since it's no longer valid.
                 # This can happen when a new PullPointSubscription is created.
-                logger.warning(
+                logger.debug(
                     "Closing service %s with %s", binding_key, existing_service.xaddr
                 )
                 # Hold a reference to the task so it doesn't get
@@ -451,6 +451,8 @@ class ONVIFCamera:
                 task.add_done_callback(self._background_tasks.remove)
                 self._background_tasks.add(task)
             self.services.pop(binding_key)
+
+        logger.debug("Creating service %s with %s", binding_key, xaddr)
 
         service = ONVIFService(
             xaddr,
@@ -463,7 +465,6 @@ class ONVIFCamera:
             binding_name=binding_name,
             binding_key=binding_key,
         )
-        logger.warning("Creating service %s with %s", binding_key, xaddr)
 
         self.services[binding_key] = service
 

--- a/onvif/client.py
+++ b/onvif/client.py
@@ -432,6 +432,9 @@ class ONVIFCamera:
         # Don't re-create bindings if the xaddr remains the same.
         # The xaddr can change when a new PullPointSubscription is created.
         binding_key = (name, port_type)
+
+        xaddr, wsdl_file, binding_name = self.get_definition(name, port_type)
+
         existing_service = self.services.get(binding_key)
         if existing_service:
             if existing_service.xaddr == xaddr:
@@ -448,8 +451,6 @@ class ONVIFCamera:
                 task.add_done_callback(self._background_tasks.remove)
                 self._background_tasks.add(task)
             self.services.pop(binding_key)
-
-        xaddr, wsdl_file, binding_name = self.get_definition(name, port_type)
 
         service = ONVIFService(
             xaddr,


### PR DESCRIPTION
A new service was being created every time the query string changed (see example below). They would get added to `self.services` each time but nothing ever removed them.

I changed the cache key to be `(name, port_type)`

If it finds the `xaddr` has changed, it closes the old one and replaces it.

I think this is safe since I expect one `xaddr` per namespace, but someone who knows about about this should validate that is a safe assumption.

```
2023-03-24 14:27:02.591 WARNING (MainThread) [homeassistant.components.onvif] Failed to fetch ONVIF PullPoint subscription messages for 'ec:71:db:22:66:ad': Device sent empty error
2023-03-24 14:27:02.808 WARNING (MainThread) [onvif] Creating service subscription {http://www.onvif.org/ver10/events/wsdl}SubscriptionManagerBindinghttp://192.168.106.66:8000/onvif/PullSubManager?Idx=1646572
2023-03-24 14:27:03.107 WARNING (MainThread) [onvif] Creating service pullpoint {http://www.onvif.org/ver10/events/wsdl}PullPointSubscriptionBindinghttp://192.168.106.66:8000/onvif/PullSubManager?Idx=1646572
2023-03-24 14:27:29.530 WARNING (MainThread) [homeassistant.components.onvif] Failed to fetch ONVIF PullPoint subscription messages for 'ec:71:db:22:66:ad': Device sent empty error
2023-03-24 14:27:29.758 WARNING (MainThread) [onvif] Creating service subscription {http://www.onvif.org/ver10/events/wsdl}SubscriptionManagerBindinghttp://192.168.106.66:8000/onvif/PullSubManager?Idx=1673511
2023-03-24 14:27:29.886 WARNING (MainThread) [onvif] Creating service pullpoint {http://www.onvif.org/ver10/events/wsdl}PullPointSubscriptionBindinghttp://192.168.106.66:8000/onvif/PullSubManager?Idx=1673511
2023-03-24 14:27:56.300 WARNING (MainThread) [homeassistant.components.onvif] Failed to fetch ONVIF PullPoint subscription messages for 'ec:71:db:22:66:ad': Device sent empty error
2023-03-24 14:27:56.484 WARNING (MainThread) [onvif] Creating service subscription {http://www.onvif.org/ver10/events/wsdl}SubscriptionManagerBindinghttp://192.168.106.66:8000/onvif/PullSubManager?Idx=1700261
2023-03-24 14:27:56.600 WARNING (MainThread) [onvif] Creating service pullpoint {http://www.onvif.org/ver10/events/wsdl}PullPointSubscriptionBindinghttp://192.168.106.66:8000/onvif/PullSubManager?Idx=1700261
2023-03-24 14:28:23.062 WARNING (MainThread) [homeassistant.components.onvif] Failed to fetch ONVIF PullPoint subscription messages for 'ec:71:db:22:66:ad': Device sent empty error
2023-03-24 14:28:23.279 WARNING (MainThread) [onvif] Creating service subscription {http://www.onvif.org/ver10/events/wsdl}SubscriptionManagerBindinghttp://192.168.106.66:8000/onvif/PullSubManager?Idx=1727032
2023-03-24 14:28:23.638 WARNING (MainThread) [onvif] Creating service pullpoint {http://www.onvif.org/ver10/events/wsdl}PullPointSubscriptionBindinghttp://192.168.106.66:8000/onvif/PullSubManager?Idx=1727032
```