### PR TITLE
Fix WSDL files being loaded multiple times and blocking the event loop

### DIFF
--- a/onvif/client.py
+++ b/onvif/client.py
@@ -13,6 +13,7 @@ from httpx import AsyncClient, BasicAuth, DigestAuth
 from zeep.cache import SqliteCache
 from zeep.client import AsyncClient as BaseZeepAsyncClient, Settings
 from zeep.exceptions import Fault
+from zeep.wsdl import Document
 import zeep.helpers
 from zeep.proxy import AsyncServiceProxy
 from zeep.transports import AsyncTransport
@@ -177,8 +178,9 @@ class ONVIFService:
         settings = Settings()
         settings.strict = False
         settings.xml_huge_tree = True
+        wsdl = Document(url, self.transport, settings)
         self.zeep_client_authless = ZeepAsyncClient(
-            wsdl=url,
+            wsdl=wsdl,
             transport=self.transport,
             settings=settings,
             plugins=[WsAddressingPlugin()],
@@ -188,7 +190,7 @@ class ONVIFService:
         )
 
         self.zeep_client = ZeepAsyncClient(
-            wsdl=url,
+            wsdl=wsdl,
             wsse=wsse,
             transport=self.transport,
             settings=settings,


### PR DESCRIPTION
This replaces the fix in #18 that was reverted in #20

Every time an config entry was being retried it would load the WSDL files in the event loop and do blocking I/O

We now only load the WSDL file only once to avoid this.

Ideally we refactor to do this in the executor but since that would require a major refactor the goal is to minimize the impact so it only affects startup.