### PR TITLE
Fine tune timeouts to reduce races

### DIFF
--- a/onvif/client.py
+++ b/onvif/client.py
@@ -734,15 +734,13 @@ class ONVIFCamera:
         """Service creation helper."""
         return await self.create_onvif_service("replay")
 
-    async def create_pullpoint_service(
-        self, read_timeout: Optional[int] = None, write_timeout: Optional[int] = None
-    ) -> ONVIFService:
+    async def create_pullpoint_service(self) -> ONVIFService:
         """Service creation helper."""
         return await self.create_onvif_service(
             "pullpoint",
             port_type="PullPointSubscription",
-            read_timeout=read_timeout or _PULLPOINT_TIMEOUT,
-            write_timeout=write_timeout or _PULLPOINT_TIMEOUT,
+            read_timeout=_PULLPOINT_TIMEOUT,
+            write_timeout=_PULLPOINT_TIMEOUT,
         )
 
     async def create_notification_service(self) -> ONVIFService:

--- a/onvif/client.py
+++ b/onvif/client.py
@@ -582,7 +582,11 @@ class ONVIFCamera:
         return xaddr, wsdlpath, binding_name
 
     async def create_onvif_service(
-        self, name: str, port_type: Optional[str] = None
+        self,
+        name: str,
+        port_type: Optional[str] = None,
+        read_timeout: Optional[int] = None,
+        write_timeout: Optional[int] = None,
     ) -> ONVIFService:
         """Create ONVIF service client"""
         name = name.lower()
@@ -619,6 +623,8 @@ class ONVIFCamera:
             dt_diff=self.dt_diff,
             binding_name=binding_name,
             binding_key=binding_key,
+            read_timeout=read_timeout,
+            write_timeout=write_timeout,
         )
         await service.setup()
 


### PR DESCRIPTION
Also adds a decorator `retry_connection_error` that can be used by callers to handle subscription renewal retries