### PR TITLE
Adjust timeouts for slower cameras

### DIFF
--- a/onvif/client.py
+++ b/onvif/client.py
@@ -35,11 +35,11 @@ _DEFAULT_SETTINGS.xml_huge_tree = True
 
 _WSDL_PATH = os.path.join(os.path.dirname(os.path.dirname(__file__)), "wsdl")
 
-_DEFAULT_TIMEOUT = 30
+_DEFAULT_TIMEOUT = 90
 _PULLPOINT_TIMEOUT = 90
 _CONNECT_TIMEOUT = 30
-_READ_TIMEOUT = 30
-_WRITE_TIMEOUT = 30
+_READ_TIMEOUT = 90
+_WRITE_TIMEOUT = 90
 
 
 KEEPALIVE_EXPIRY = 4


### PR DESCRIPTION
Lowering the read timeout to 30s was still no long enough for some of the slower cameras