### PR TITLE
Adjust timeouts to avoid blocking startup

### DIFF
--- a/onvif/client.py
+++ b/onvif/client.py
@@ -36,7 +36,7 @@ _DEFAULT_SETTINGS.xml_huge_tree = True
 _WSDL_PATH = os.path.join(os.path.dirname(os.path.dirname(__file__)), "wsdl")
 
 _DEFAULT_TIMEOUT = 30
-_PULLPOINT_TIMEOUT = 90
+_PULLPOINT_TIMEOUT = 80
 _CONNECT_TIMEOUT = 30
 _READ_TIMEOUT = 30
 _WRITE_TIMEOUT = 30

--- a/onvif/client.py
+++ b/onvif/client.py
@@ -35,11 +35,11 @@ _DEFAULT_SETTINGS.xml_huge_tree = True
 
 _WSDL_PATH = os.path.join(os.path.dirname(os.path.dirname(__file__)), "wsdl")
 
-_DEFAULT_TIMEOUT = 90
+_DEFAULT_TIMEOUT = 30
 _PULLPOINT_TIMEOUT = 90
 _CONNECT_TIMEOUT = 30
-_READ_TIMEOUT = 90
-_WRITE_TIMEOUT = 90
+_READ_TIMEOUT = 30
+_WRITE_TIMEOUT = 30
 
 
 KEEPALIVE_EXPIRY = 4


### PR DESCRIPTION
We need to keep the timeouts high for pull point since its a 60s long poll, but there is no reason to wait 90s for a response for other requests as it delays startup when there is a problem with the camera