### PR TITLE
Fix loading datetimes with - instead of T

### DIFF
--- a/onvif/types.py
+++ b/onvif/types.py
@@ -1,0 +1,29 @@
+"""ONVIF types."""
+
+
+import ciso8601
+import isodate
+from zeep.xsd.types.builtins import DateTime, treat_whitespace
+
+
+# see https://github.com/mvantellingen/python-zeep/pull/1370
+class FastDateTime(DateTime):
+    """Fast DateTime that supports timestamps with - instead of T."""
+
+    @treat_whitespace("collapse")
+    def pythonvalue(self, value):
+        """Convert the xml value into a python value."""
+        try:
+            return ciso8601.parse_datetime(value)
+        except ValueError:
+            pass
+        # Determine based on the length of the value if it only contains a date
+        # lazy hack ;-)
+
+        if len(value) == 10:
+            value += "T00:00:00"
+        elif (len(value) == 19 or len(value) == 26) and value[10] == " ":
+            value = "T".join(value.split(" "))
+        elif len(value) > 10 and value[10] == "-":  # 2010-01-01-00:00:00...
+            value[10] = "T"
+        return isodate.parse_datetime(value)

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,12 @@ here = os.path.abspath(os.path.dirname(__file__))
 version_path = os.path.join(here, "onvif/version.txt")
 version = open(version_path).read().strip()
 
-requires = ["httpx>=0.19.0,<1.0.0", "zeep[async]>=4.2.1,<5.0.0"]
+requires = [
+    "httpx>=0.19.0,<1.0.0",
+    "zeep[async]>=4.2.1,<5.0.0",
+    "ciso8601>=2.1.3",
+    "isodate>=0.6.0",
+]
 
 CLASSIFIERS = [
     "Development Status :: 3 - Alpha",


### PR DESCRIPTION
This is a workaround for
https://github.com/mvantellingen/python-zeep/pull/1370

issue https://github.com/home-assistant/core/issues/91089