### PR TITLE
Fix sending WSAs if they are already present

### DIFF
--- a/onvif/client.py
+++ b/onvif/client.py
@@ -14,7 +14,6 @@ from zeep.client import AsyncClient as BaseZeepAsyncClient
 import zeep.helpers
 from zeep.proxy import AsyncServiceProxy
 from zeep.transports import AsyncTransport
-from .wsa import WsAddressingIfMissingPlugin
 from zeep.wsdl import Document
 from zeep.wsse.username import UsernameToken
 
@@ -28,6 +27,7 @@ from .transport import ASYNC_TRANSPORT
 from .types import FastDateTime
 from .util import create_no_verify_ssl_context, normalize_url, path_isfile, utcnow
 from .wrappers import retry_connection_error  # noqa: F401
+from .wsa import WsAddressingIfMissingPlugin
 
 logger = logging.getLogger("onvif")
 logging.basicConfig(level=logging.INFO)

--- a/onvif/client.py
+++ b/onvif/client.py
@@ -14,7 +14,7 @@ from zeep.client import AsyncClient as BaseZeepAsyncClient
 import zeep.helpers
 from zeep.proxy import AsyncServiceProxy
 from zeep.transports import AsyncTransport
-from zeep.wsa import WsAddressingPlugin
+from .wsa import WsAddressingIfMissingPlugin
 from zeep.wsdl import Document
 from zeep.wsse.username import UsernameToken
 
@@ -242,7 +242,7 @@ class ONVIFService:
             wsdl=self.document,
             transport=self.transport,
             settings=settings,
-            plugins=[WsAddressingPlugin()],
+            plugins=[WsAddressingIfMissingPlugin()],
         )
         self.ws_client_authless = self.zeep_client_authless.create_service(
             binding_name, self.xaddr
@@ -252,7 +252,7 @@ class ONVIFService:
             wsse=wsse,
             transport=self.transport,
             settings=settings,
-            plugins=[WsAddressingPlugin()],
+            plugins=[WsAddressingIfMissingPlugin()],
         )
         self.ws_client = self.zeep_client.create_service(binding_name, self.xaddr)
         namespace = binding_name[binding_name.find("{") + 1 : binding_name.find("}")]

--- a/onvif/util.py
+++ b/onvif/util.py
@@ -7,7 +7,7 @@ from functools import lru_cache, partial
 import os
 import ssl
 from typing import Any
-from urllib.parse import urlparse, urlunparse, ParseResultBytes
+from urllib.parse import ParseResultBytes, urlparse, urlunparse
 
 from zeep.exceptions import Fault
 

--- a/onvif/wsa.py
+++ b/onvif/wsa.py
@@ -1,0 +1,46 @@
+import uuid
+
+from lxml import etree
+from lxml.builder import ElementMaker
+
+from zeep import ns
+from zeep.plugins import Plugin
+from zeep.wsdl.utils import get_or_create_header
+
+WSA = ElementMaker(namespace=ns.WSA, nsmap={"wsa": ns.WSA})
+
+
+class WsAddressingIfMissingPlugin(Plugin):
+    nsmap = {"wsa": ns.WSA}
+
+    def __init__(self, address_url: str = None):
+        self.address_url = address_url
+
+    def egress(self, envelope, http_headers, operation, binding_options):
+        """Apply the ws-addressing headers to the given envelope."""
+
+        wsa_action = operation.abstract.wsa_action
+        if not wsa_action:
+            wsa_action = operation.soapaction
+
+        header = get_or_create_header(envelope)
+        for elem in header:
+            if (elem.prefix or "").startswith("wsa"):
+                # WSA header already exists
+                return envelope, http_headers
+
+        headers = [
+            WSA.Action(wsa_action),
+            WSA.MessageID("urn:uuid:" + str(uuid.uuid4())),
+            WSA.To(self.address_url or binding_options["address"]),
+        ]
+        header.extend(headers)
+
+        # the top_nsmap kwarg was added in lxml 3.5.0
+        if etree.LXML_VERSION[:2] >= (3, 5):
+            etree.cleanup_namespaces(
+                header, keep_ns_prefixes=header.nsmap, top_nsmap=self.nsmap
+            )
+        else:
+            etree.cleanup_namespaces(header)
+        return envelope, http_headers

--- a/onvif/wsa.py
+++ b/onvif/wsa.py
@@ -2,7 +2,6 @@ import uuid
 
 from lxml import etree
 from lxml.builder import ElementMaker
-
 from zeep import ns
 from zeep.plugins import Plugin
 from zeep.wsdl.utils import get_or_create_header

--- a/onvif/wsa.py
+++ b/onvif/wsa.py
@@ -18,16 +18,15 @@ class WsAddressingIfMissingPlugin(Plugin):
 
     def egress(self, envelope, http_headers, operation, binding_options):
         """Apply the ws-addressing headers to the given envelope."""
-
-        wsa_action = operation.abstract.wsa_action
-        if not wsa_action:
-            wsa_action = operation.soapaction
-
         header = get_or_create_header(envelope)
         for elem in header:
             if (elem.prefix or "").startswith("wsa"):
                 # WSA header already exists
                 return envelope, http_headers
+
+        wsa_action = operation.abstract.wsa_action
+        if not wsa_action:
+            wsa_action = operation.soapaction
 
         headers = [
             WSA.Action(wsa_action),


### PR DESCRIPTION
I copied the `WsAddressingPlugin` from zeep and modified it to not add the WSAs if they are already present and called it `WsAddressingIfMissingPlugin`

This should prevent regressing cameras that need them added and still keep the ones that already have them working

https://github.com/home-assistant/core/issues/91089