### PR TITLE
Replace datetime.utcnow

### DIFF
--- a/onvif/client.py
+++ b/onvif/client.py
@@ -72,7 +72,7 @@ class UsernameDigestTokenDtDiff(UsernameToken):
     def apply(self, envelope, headers):
         old_created = self.created
         if self.created is None:
-            self.created = dt.datetime.utcnow()
+            self.created = dt.datetime.now(tz=dt.timezone.utc).replace(tzinfo=None)
         if self.dt_diff is not None:
             self.created += self.dt_diff
         result = super().apply(envelope, headers)


### PR DESCRIPTION
Starting with Python 3.12 `datetime.utcnow` will be deprecated.
https://docs.python.org/3.12/library/datetime.html#datetime.datetime.utcnow