### PR TITLE
Handle "Not enough data to satisfy content length header" errors from broken cameras & NVRs

### DIFF
--- a/onvif/client.py
+++ b/onvif/client.py
@@ -7,7 +7,7 @@ import datetime as dt
 import logging
 import os.path
 from collections.abc import Callable
-from typing import Any
+from typing import Any, TypeVar
 
 import zeep.helpers
 from zeep.cache import SqliteCache
@@ -162,6 +162,27 @@ async def _cached_document(url: str) -> Document:
     document = await loop.run_in_executor(None, _load_document)
     _DOCUMENT_CACHE[url] = document
     return document
+
+
+_T = TypeVar("_T")
+
+
+def handle_snapshot_errors(func: Callable[..., _T]) -> Callable[..., _T]:
+    """Decorator to handle snapshot URI errors."""
+
+    async def wrapper(self, uri: str, *args: Any, **kwargs: Any) -> _T:
+        try:
+            return await func(self, uri, *args, **kwargs)
+        except TimeoutError as error:
+            raise ONVIFTimeoutError(
+                f"Timed out fetching {obscure_user_pass_url(uri)}: {error}"
+            ) from error
+        except aiohttp.ClientError as error:
+            raise ONVIFError(
+                f"Error fetching {obscure_user_pass_url(uri)}: {error}"
+            ) from error
+
+    return wrapper
 
 
 class ZeepAsyncClient(BaseZeepAsyncClient):
@@ -601,7 +622,7 @@ class ONVIFCamera:
                 middlewares = (DigestAuthMiddleware(self.user, self.passwd),)
 
         response = await self._try_snapshot_uri(uri, auth=auth, middlewares=middlewares)
-        content = await response.read()
+        content = await self._try_read_snapshot_content(uri, response)
 
         # If the request fails with a 401, strip user/pass from URL and retry
         if (
@@ -612,7 +633,7 @@ class ONVIFCamera:
             response = await self._try_snapshot_uri(
                 stripped_uri, auth=auth, middlewares=middlewares
             )
-            content = await response.read()
+            content = await self._try_read_snapshot_content(uri, response)
 
         if response.status == 401:
             raise ONVIFAuthError(f"Failed to authenticate to {uri}")
@@ -622,24 +643,23 @@ class ONVIFCamera:
 
         return None
 
+    @handle_snapshot_errors
+    async def _try_read_snapshot_content(
+        self,
+        uri: str,
+        response: aiohttp.ClientResponse,
+    ) -> bytes:
+        """Try to read the snapshot URI."""
+        return await response.read()
+
+    @handle_snapshot_errors
     async def _try_snapshot_uri(
         self,
         uri: str,
         auth: BasicAuth | None = None,
         middlewares: tuple[DigestAuthMiddleware, ...] | None = None,
     ) -> aiohttp.ClientResponse:
-        try:
-            return await self._snapshot_client.get(
-                uri, auth=auth, middlewares=middlewares
-            )
-        except TimeoutError as error:
-            raise ONVIFTimeoutError(
-                f"Timed out fetching {obscure_user_pass_url(uri)}: {error}"
-            ) from error
-        except aiohttp.ClientError as error:
-            raise ONVIFError(
-                f"Error fetching {obscure_user_pass_url(uri)}: {error}"
-            ) from error
+        return await self._snapshot_client.get(uri, auth=auth, middlewares=middlewares)
 
     def get_definition(
         self, name: str, port_type: str | None = None

--- a/onvif/zeep_aiohttp.py
+++ b/onvif/zeep_aiohttp.py
@@ -171,6 +171,9 @@ class AIOHTTPTransport(Transport):
 
             # Convert to httpx Response
             return self._aiohttp_to_httpx_response(response, content)
+        except RuntimeError as exc:
+            # Handle RuntimeError which may occur if the session is closed
+            raise RuntimeError(f"Failed to post to {address}: {exc}") from exc
 
         except TimeoutError as exc:
             raise TimeoutError(f"Request to {address} timed out") from exc
@@ -248,6 +251,9 @@ class AIOHTTPTransport(Transport):
 
             # Convert directly to requests.Response
             return self._aiohttp_to_requests_response(response, content)
+        except RuntimeError as exc:
+            # Handle RuntimeError which may occur if the session is closed
+            raise RuntimeError(f"Failed to get from {address}: {exc}") from exc
 
         except TimeoutError as exc:
             raise TimeoutError(f"Request to {address} timed out") from exc


### PR DESCRIPTION
## Summary
- Added error handling for `response.read()` to catch "Not enough data to satisfy content length header" errors
- Fixes issues with broken Dahua and Lorex cameras that return invalid Content-Length headers
- Refactored error handling into a reusable `handle_snapshot_errors` decorator

## Problem
Certain Dahua and Lorex camera models return invalid Content-Length headers that are larger or smaller than the actual response body. This causes `response.read()` to either:
- Hang indefinitely waiting for data that will never arrive
- Fail with `aiohttp.ClientPayloadError: Not enough data to satisfy content length header`

Previously, these errors during the content read phase were not being caught, causing snapshot retrieval to fail with unhandled exceptions which could cause Home Assistant to not be able to setup these devices.

## Solution
This PR fixes the issue by:

1. Creating a new `_try_read_snapshot_content` method that wraps `response.read()` with proper error handling
2. Implementing a `handle_snapshot_errors` decorator that catches:
   - `TimeoutError` → converts to `ONVIFTimeoutError` 
   - `aiohttp.ClientError` (including `ClientPayloadError`) → converts to `ONVIFError`
3. Applying the decorator to both:
   - `_try_snapshot_uri` (for connection errors)
   - `_try_read_snapshot_content` (for read/payload errors)

Now when these broken cameras cause payload errors or timeouts during content reading, they're properly caught and converted to appropriate ONVIF exceptions.

## Related Issues
Fixes https://github.com/home-assistant/core/issues/148093