### PR TITLE
feat: introduce TopicFilter support

### DIFF
--- a/onvif/client.py
+++ b/onvif/client.py
@@ -27,7 +27,7 @@ from .const import KEEPALIVE_EXPIRY
 from .managers import NotificationManager, PullPointManager
 from .settings import DEFAULT_SETTINGS
 from .transport import ASYNC_TRANSPORT
-from .types import FastDateTime, ForgivingTime
+from .types import FastDateTime, ForgivingTime, TopicExpression
 from .util import (
     create_no_verify_ssl_context,
     normalize_url,
@@ -564,9 +564,21 @@ class ONVIFCamera:
         self,
         interval: dt.timedelta,
         subscription_lost_callback: Callable[[], None],
+        topic_filter: str | None = None,
+        topic_filter_dialect: str = TopicExpression.DIALECT,
     ) -> PullPointManager:
-        """Create a pullpoint manager."""
-        manager = PullPointManager(self, interval, subscription_lost_callback)
+        """Create a pullpoint manager.
+
+        See :class:`onvif.managers.PullPointManager` for ``topic_filter`` and
+        ``topic_filter_dialect`` semantics.
+        """
+        manager = PullPointManager(
+            self,
+            interval,
+            subscription_lost_callback,
+            topic_filter,
+            topic_filter_dialect,
+        )
         await manager.start()
         return manager
 

--- a/onvif/managers.py
+++ b/onvif/managers.py
@@ -18,8 +18,10 @@ from onvif.exceptions import ONVIFError
 
 from .settings import DEFAULT_SETTINGS
 from .transport import ASYNC_TRANSPORT
+from .types import TopicExpression
 from .util import normalize_url, stringify_onvif_error
 from .wrappers import retry_connection_error
+
 
 logger = logging.getLogger("onvif")
 
@@ -34,6 +36,7 @@ SUBSCRIPTION_RESTART_INTERVAL_ON_ERROR = dt.timedelta(seconds=40)
 # this value, we will use this value instead to prevent subscribing over and over
 # again.
 MINIMUM_SUBSCRIPTION_SECONDS = 60.0
+MINIMUM_SUBSCRIPTION_INTERVAL = dt.timedelta(seconds=MINIMUM_SUBSCRIPTION_SECONDS)
 
 if TYPE_CHECKING:
     from onvif.client import ONVIFCamera, ONVIFService
@@ -50,7 +53,7 @@ class BaseManager:
     ) -> None:
         """Initialize the notification processor."""
         self._device = device
-        self._interval = interval
+        self._interval = max(interval, MINIMUM_SUBSCRIPTION_INTERVAL)
         self._subscription: ONVIFService | None = None
         self._restart_or_renew_task: asyncio.Task | None = None
         self._loop = asyncio.get_event_loop()
@@ -290,6 +293,53 @@ class NotificationManager(BaseManager):
 class PullPointManager(BaseManager):
     """Manager for PullPoint."""
 
+    def __init__(
+        self,
+        device: ONVIFCamera,
+        interval: dt.timedelta,
+        subscription_lost_callback: Callable[[], None],
+        topic_filter: str | None = None,
+        topic_filter_dialect: str = TopicExpression.DIALECT,
+    ) -> None:
+        """Create a Manager for PullPoint.
+
+        :param device: ONVIFCamera the manager attaches to.
+        :param interval: Termination time of the PullPoint session. Values
+            below :data:`MINIMUM_SUBSCRIPTION_INTERVAL` are raised to that
+            floor.
+        :param subscription_lost_callback: Called when the subscription is
+            lost and cannot be re-established.
+        :param topic_filter: An optional topic expression used to restrict
+            the topics the subscription will listen to. The expression's
+            grammar is determined by ``topic_filter_dialect``.
+        :param topic_filter_dialect: WS-Topic dialect URI used to serialise
+            ``topic_filter``. Defaults to the ONVIF ConcreteSet dialect
+            (``http://www.onvif.org/ver10/tev/topicExpression/ConcreteSet``).
+            Use ``http://docs.oasis-open.org/wsn/t-1/TopicExpression/Full``
+            (or any other URI the camera advertises) to send a different
+            grammar.
+
+        :raises ValueError: If ``topic_filter`` is provided but blank.
+
+        Notes:
+            If your ONVIFCamera has a FixedTopicSet, you will likely not
+            be able to use wildcards in your ``topic_filter``.
+
+        Examples:
+            >>> from datetime import timedelta
+            >>> PullPointManager(
+            ...     cam,
+            ...     timedelta(seconds=60),
+            ...     lambda: print("Lost connection!"),
+            ...     "tns1:RuleEngine/CellMotionDetector/Motion",
+            ... )
+        """
+        if topic_filter is not None and not topic_filter.strip():
+            raise ValueError("topic_filter must be a non-empty string or None")
+        self._topic_filter: str | None = topic_filter
+        self._topic_filter_dialect: str = topic_filter_dialect
+        super().__init__(device, interval, subscription_lost_callback)
+
     async def _start(self) -> float:
         """
         Start the PullPoint manager.
@@ -299,13 +349,24 @@ class PullPointManager(BaseManager):
         device = self._device
         logger.debug("%s: Setup the PullPoint manager", device.host)
         events_service = await device.create_events_service()
-        result = await events_service.CreatePullPointSubscription(
-            {
-                "InitialTerminationTime": device.get_next_termination_time(
-                    self._interval
-                ),
+
+        subscription_params: dict[str, Any] = {
+            "InitialTerminationTime": device.get_next_termination_time(self._interval),
+        }
+        if self._topic_filter:
+            # WS-Notification FilterType is xs:any maxOccurs="unbounded";
+            # zeep represents it as a list of AnyObject children.
+            subscription_params["Filter"] = {
+                "_value_1": [
+                    TopicExpression.from_client(
+                        events_service.zeep_client,
+                        self._topic_filter,
+                        self._topic_filter_dialect,
+                    )
+                ],
             }
-        )
+
+        result = await events_service.CreatePullPointSubscription(subscription_params)
         # pylint: disable=protected-access
         device.xaddrs[
             "http://www.onvif.org/ver10/events/wsdl/PullPointSubscription"

--- a/onvif/types.py
+++ b/onvif/types.py
@@ -2,7 +2,12 @@
 
 from datetime import datetime, timedelta, time
 import ciso8601
+from zeep.client import Client
+from zeep.xsd.types.any import AnyObject
+from zeep.xsd.types.complex import ComplexType
 from zeep.xsd.types.builtins import DateTime, treat_whitespace, Time
+from zeep.xsd.elements import Element
+
 import isodate
 
 
@@ -100,3 +105,39 @@ class ForgivingTime(Time):
         if fixed_dt := _try_parse_datetime(f"2024-01-15T{fixed_time}Z"):
             return (fixed_dt + timedelta(**offset)).time()
         return isodate.parse_time(value)
+
+
+class TopicExpression(AnyObject):
+    """WS-BaseNotification ``TopicExpression`` element wrapper.
+
+    Wraps a topic filter string together with its dialect URI so it can be
+    embedded in a zeep ``FilterType._value_1`` list when calling
+    ``CreatePullPointSubscription``.
+
+    The default dialect is ONVIF's ``ConcreteSet`` (no wildcards or boolean
+    operators); pass ``dialect=`` to use a different WS-Topic grammar such as
+    the OASIS Full dialect.
+    """
+
+    NAMESPACE = "{http://docs.oasis-open.org/wsn/b-2}"
+    DIALECT = "http://www.onvif.org/ver10/tev/topicExpression/ConcreteSet"
+
+    def __init__(
+        self,
+        topic_expression_type: ComplexType,
+        value: str,
+        dialect: str = DIALECT,
+    ) -> None:
+        expression = Element(f"{self.NAMESPACE}TopicExpression", topic_expression_type)
+        super().__init__(
+            expression, topic_expression_type(_value_1=value, Dialect=dialect)
+        )
+
+    @classmethod
+    def from_client(
+        cls, client: Client, expression: str, dialect: str = DIALECT
+    ) -> "TopicExpression":
+        """Build a TopicExpression using the WSN-B type from ``client``."""
+        return cls(
+            client.get_type(f"{cls.NAMESPACE}TopicExpressionType"), expression, dialect
+        )

--- a/tests/fake_hikvision.py
+++ b/tests/fake_hikvision.py
@@ -39,6 +39,7 @@ EVENTS_SERVICE_PATH = "/onvif/Events"
 IMAGING_SERVICE_PATH = "/onvif/Imaging"
 PTZ_SERVICE_PATH = "/onvif/PTZ"
 ANALYTICS_SERVICE_PATH = "/onvif/Analytics"
+SUBSCRIPTION_SERVICE_PATH = "/onvif/Subscription"
 
 
 def _soap_envelope(body: str) -> str:
@@ -223,6 +224,17 @@ class FakeHikvisionCamera:
             "</tev:CreatePullPointSubscriptionResponse>"
         )
 
+    def _unsubscribe_response(self) -> str:
+        return _soap_envelope("<wsnt:UnsubscribeResponse/>")
+
+    def _renew_response(self) -> str:
+        return _soap_envelope(
+            "<wsnt:RenewResponse>"
+            f"<wsnt:CurrentTime>{self.pullpoint_current_time}</wsnt:CurrentTime>"
+            f"<wsnt:TerminationTime>{self.pullpoint_termination_time}</wsnt:TerminationTime>"
+            "</wsnt:RenewResponse>"
+        )
+
     def _response_for(self, operation: str) -> str | None:
         builders = {
             "GetCapabilities": self._capabilities_response,
@@ -232,6 +244,8 @@ class FakeHikvisionCamera:
             "CreatePullPointSubscription": (
                 self._create_pullpoint_subscription_response
             ),
+            "Unsubscribe": self._unsubscribe_response,
+            "Renew": self._renew_response,
         }
         builder = builders.get(operation)
         return builder() if builder else None
@@ -294,6 +308,7 @@ class FakeHikvisionCamera:
             IMAGING_SERVICE_PATH,
             PTZ_SERVICE_PATH,
             ANALYTICS_SERVICE_PATH,
+            SUBSCRIPTION_SERVICE_PATH,
         ):
             app.router.add_post(path, self._handle)
         self._runner = web.AppRunner(app)

--- a/tests/test_hikvision_e2e.py
+++ b/tests/test_hikvision_e2e.py
@@ -22,6 +22,11 @@ from onvif import ONVIFCamera
 # fake_hikvision is a sibling test helper; pytest puts tests/ on sys.path.
 from fake_hikvision import WSSE_NS, FakeHikvisionCamera
 
+WSNT_NS = "http://docs.oasis-open.org/wsn/b-2"
+ONVIF_CONCRETE_SET_DIALECT = (
+    "http://www.onvif.org/ver10/tev/topicExpression/ConcreteSet"
+)
+
 WSDL_DIR = os.path.join(os.path.dirname(onvif.__file__), "wsdl")
 DIGEST_TYPE = (
     "http://docs.oasis-open.org/wss/2004/01/"
@@ -303,3 +308,106 @@ async def test_camera_rejecting_unauthenticated_requests() -> None:
     request = camera.last_request("GetDeviceInformation")
     assert request is not None
     assert request.username == "admin"
+
+
+@pytest.mark.asyncio
+async def test_pullpoint_manager_omits_filter_by_default(
+    fake_camera: FakeHikvisionCamera, onvif_camera: ONVIFCamera
+) -> None:
+    """Without ``topic_filter`` the CreatePullPointSubscription has no Filter.
+
+    Regression guard so the new optional parameter cannot accidentally start
+    sending an empty Filter to cameras that do not support filtering.
+    """
+    await onvif_camera.update_xaddrs()
+
+    manager = await onvif_camera.create_pullpoint_manager(
+        dt.timedelta(seconds=60), lambda: None
+    )
+    try:
+        request = fake_camera.last_request("CreatePullPointSubscription")
+        assert request is not None
+        # No Filter element of any namespace and no TopicExpression at all.
+        envelope = request.envelope
+        assert envelope.find(".//{*}Filter") is None
+        assert envelope.find(f".//{{{WSNT_NS}}}TopicExpression") is None
+    finally:
+        manager.pause()
+        await manager.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_pullpoint_manager_sends_topic_filter(
+    fake_camera: FakeHikvisionCamera, onvif_camera: ONVIFCamera
+) -> None:
+    """``topic_filter`` is serialised as wsnt:Filter/wsnt:TopicExpression.
+
+    Drives the full pipeline -- including zeep's :class:`AnyObject`
+    serialisation of the WS-Notification FilterType -- against the fake
+    camera and asserts on the bytes received.
+    """
+    await onvif_camera.update_xaddrs()
+
+    topic = "tns1:RuleEngine/CellMotionDetector/Motion"
+    manager = await onvif_camera.create_pullpoint_manager(
+        dt.timedelta(seconds=60), lambda: None, topic_filter=topic
+    )
+    try:
+        request = fake_camera.last_request("CreatePullPointSubscription")
+        assert request is not None
+
+        envelope = request.envelope
+        filter_el = envelope.find(".//{*}Filter")
+        assert filter_el is not None
+
+        topic_expr = filter_el.find(f"{{{WSNT_NS}}}TopicExpression")
+        assert topic_expr is not None
+        assert topic_expr.get("Dialect") == ONVIF_CONCRETE_SET_DIALECT
+        assert (topic_expr.text or "").strip() == topic
+    finally:
+        manager.pause()
+        await manager.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_pullpoint_manager_sends_custom_dialect(
+    fake_camera: FakeHikvisionCamera, onvif_camera: ONVIFCamera
+) -> None:
+    """A caller-supplied ``topic_filter_dialect`` lands on the wire."""
+    await onvif_camera.update_xaddrs()
+
+    full_dialect = "http://docs.oasis-open.org/wsn/t-1/TopicExpression/Full"
+    manager = await onvif_camera.create_pullpoint_manager(
+        dt.timedelta(seconds=60),
+        lambda: None,
+        topic_filter="tns1:RuleEngine//.",
+        topic_filter_dialect=full_dialect,
+    )
+    try:
+        request = fake_camera.last_request("CreatePullPointSubscription")
+        assert request is not None
+        topic_expr = request.envelope.find(
+            f".//{{*}}Filter/{{{WSNT_NS}}}TopicExpression"
+        )
+        assert topic_expr is not None
+        assert topic_expr.get("Dialect") == full_dialect
+    finally:
+        manager.pause()
+        await manager.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_pullpoint_manager_unsubscribes_on_shutdown(
+    fake_camera: FakeHikvisionCamera, onvif_camera: ONVIFCamera
+) -> None:
+    """``shutdown()`` issues a WS-BaseNotification Unsubscribe to the camera."""
+    await onvif_camera.update_xaddrs()
+
+    manager = await onvif_camera.create_pullpoint_manager(
+        dt.timedelta(seconds=60), lambda: None
+    )
+    await manager.shutdown()
+
+    unsubscribe = fake_camera.last_request("Unsubscribe")
+    assert unsubscribe is not None
+    assert unsubscribe.path == "/onvif/Subscription"

--- a/tests/test_managers.py
+++ b/tests/test_managers.py
@@ -1,0 +1,118 @@
+"""Unit tests for the subscription managers."""
+
+from __future__ import annotations
+
+import datetime as dt
+import os
+
+import pytest
+
+import onvif
+from onvif import ONVIFCamera
+from onvif.managers import (
+    MINIMUM_SUBSCRIPTION_INTERVAL,
+    NotificationManager,
+    PullPointManager,
+)
+
+WSDL_DIR = os.path.join(os.path.dirname(onvif.__file__), "wsdl")
+
+
+def _device() -> ONVIFCamera:
+    """Build a minimal ONVIFCamera for manager construction tests."""
+    return ONVIFCamera("127.0.0.1", 80, "user", "pass", wsdl_dir=WSDL_DIR)
+
+
+@pytest.mark.asyncio
+async def test_base_manager_floors_short_interval() -> None:
+    """A 10-second interval is raised to the 60-second minimum."""
+    manager = PullPointManager(
+        _device(), dt.timedelta(seconds=10), lambda: None
+    )
+    assert manager._interval == MINIMUM_SUBSCRIPTION_INTERVAL
+
+
+@pytest.mark.asyncio
+async def test_base_manager_preserves_minimum_interval() -> None:
+    """An interval equal to the minimum is preserved."""
+    manager = PullPointManager(
+        _device(), MINIMUM_SUBSCRIPTION_INTERVAL, lambda: None
+    )
+    assert manager._interval == MINIMUM_SUBSCRIPTION_INTERVAL
+
+
+@pytest.mark.asyncio
+async def test_base_manager_does_not_cap_long_interval() -> None:
+    """Intervals above the minimum are kept verbatim.
+
+    Regression test for the inverted clamp introduced in the original
+    TopicFilter PR which capped intervals to 60s instead of flooring at 60s.
+    """
+    five_minutes = dt.timedelta(minutes=5)
+    manager = PullPointManager(_device(), five_minutes, lambda: None)
+    assert manager._interval == five_minutes
+
+
+@pytest.mark.asyncio
+async def test_notification_manager_inherits_interval_floor() -> None:
+    """The floor applies to NotificationManager too."""
+    manager = NotificationManager(
+        _device(),
+        "http://example.com/onvif/notify",
+        dt.timedelta(seconds=5),
+        lambda: None,
+    )
+    assert manager._interval == MINIMUM_SUBSCRIPTION_INTERVAL
+
+
+@pytest.mark.asyncio
+async def test_pullpoint_manager_defaults_have_no_topic_filter() -> None:
+    """Default construction leaves ``_topic_filter`` unset."""
+    manager = PullPointManager(
+        _device(), dt.timedelta(seconds=60), lambda: None
+    )
+    assert manager._topic_filter is None
+
+
+@pytest.mark.asyncio
+async def test_pullpoint_manager_stores_topic_filter_and_default_dialect() -> None:
+    """A topic filter is recorded with the ConcreteSet default dialect."""
+    manager = PullPointManager(
+        _device(),
+        dt.timedelta(seconds=60),
+        lambda: None,
+        topic_filter="tns1:RuleEngine/CellMotionDetector/Motion",
+    )
+    assert manager._topic_filter == "tns1:RuleEngine/CellMotionDetector/Motion"
+    assert manager._topic_filter_dialect == (
+        "http://www.onvif.org/ver10/tev/topicExpression/ConcreteSet"
+    )
+
+
+@pytest.mark.asyncio
+async def test_pullpoint_manager_stores_custom_dialect() -> None:
+    """A caller can override the WS-Topic dialect URI."""
+    full_dialect = "http://docs.oasis-open.org/wsn/t-1/TopicExpression/Full"
+    manager = PullPointManager(
+        _device(),
+        dt.timedelta(seconds=60),
+        lambda: None,
+        topic_filter="tns1:RuleEngine//.",
+        topic_filter_dialect=full_dialect,
+    )
+    assert manager._topic_filter_dialect == full_dialect
+
+
+@pytest.mark.parametrize("blank", ["", "   ", "\t\n"])
+@pytest.mark.asyncio
+async def test_pullpoint_manager_rejects_blank_topic_filter(blank: str) -> None:
+    """Blank topic filters are rejected up-front, not silently sent."""
+    with pytest.raises(ValueError, match="topic_filter must be a non-empty"):
+        PullPointManager(
+            _device(),
+            dt.timedelta(seconds=60),
+            lambda: None,
+            topic_filter=blank,
+        )
+
+

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -8,7 +8,7 @@ import datetime
 from onvif.client import ONVIFCamera
 from onvif.settings import DEFAULT_SETTINGS
 from onvif.transport import ASYNC_TRANSPORT
-from onvif.types import FastDateTime, ForgivingTime
+from onvif.types import FastDateTime, ForgivingTime, TopicExpression
 
 INVALID_TERM_TIME = b'<?xml version="1.0" encoding="UTF-8"?>\r\n<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://www.w3.org/2003/05/soap-envelope" xmlns:SOAP-ENC="http://www.w3.org/2003/05/soap-encoding" xmlns:tev="http://www.onvif.org/ver10/events/wsdl" xmlns:wsnt="http://docs.oasis-open.org/wsn/b-2" xmlns:wsa5="http://www.w3.org/2005/08/addressing" xmlns:chan="http://schemas.microsoft.com/ws/2005/02/duplex" xmlns:wsa="http://www.w3.org/2005/08/addressing" xmlns:tt="http://www.onvif.org/ver10/schema" xmlns:tns1="http://www.onvif.org/ver10/topics">\r\n<SOAP-ENV:Header>\r\n<wsa5:Action>http://www.onvif.org/ver10/events/wsdl/PullPointSubscription/PullMessagesResponse</wsa5:Action>\r\n</SOAP-ENV:Header>\r\n<SOAP-ENV:Body>\r\n<tev:PullMessagesResponse>\r\n<tev:CurrentTime>2024-08-17T00:56:16Z</tev:CurrentTime>\r\n<tev:TerminationTime>2024-08-17T00:61:16Z</tev:TerminationTime>\r\n</tev:PullMessagesResponse>\r\n</SOAP-ENV:Body>\r\n</SOAP-ENV:Envelope>\r\n'
 _WSDL_PATH = os.path.join(os.path.dirname(os.path.dirname(__file__)), "onvif", "wsdl")
@@ -121,3 +121,52 @@ def test_fix_time_overflow() -> None:
 def test_unfixable_time_overflow() -> None:
     with pytest.raises(ValueError, match="Unrecognised ISO 8601 time format"):
         assert ForgivingTime().pythonvalue("999:00:00")
+
+
+WSNT_NS = "http://docs.oasis-open.org/wsn/b-2"
+ONVIF_CONCRETE_SET_DIALECT = (
+    "http://www.onvif.org/ver10/tev/topicExpression/ConcreteSet"
+)
+
+
+@pytest.mark.asyncio
+async def test_topic_expression_default_dialect() -> None:
+    """from_client defaults to the ONVIF ConcreteSet dialect."""
+    device = ONVIFCamera("127.0.0.1", 80, "user", "pass", wsdl_dir=_WSDL_PATH)
+    device.xaddrs = {
+        "http://www.onvif.org/ver10/events/wsdl": "http://192.168.1.1/onvif/Events"
+    }
+    events = await device.create_events_service()
+
+    expr = TopicExpression.from_client(
+        events.zeep_client, "tns1:RuleEngine/CellMotionDetector/Motion"
+    )
+
+    assert expr.value._value_1 == "tns1:RuleEngine/CellMotionDetector/Motion"
+    assert expr.value.Dialect == ONVIF_CONCRETE_SET_DIALECT
+    assert expr.xsd_elm.qname.text == f"{{{WSNT_NS}}}TopicExpression"
+
+
+@pytest.mark.asyncio
+async def test_topic_expression_custom_dialect() -> None:
+    """A caller-supplied dialect is preserved on the wire."""
+    device = ONVIFCamera("127.0.0.1", 80, "user", "pass", wsdl_dir=_WSDL_PATH)
+    device.xaddrs = {
+        "http://www.onvif.org/ver10/events/wsdl": "http://192.168.1.1/onvif/Events"
+    }
+    events = await device.create_events_service()
+    full_dialect = "http://docs.oasis-open.org/wsn/t-1/TopicExpression/Full"
+
+    expr = TopicExpression.from_client(
+        events.zeep_client,
+        "tns1:RuleEngine//.",
+        dialect=full_dialect,
+    )
+
+    assert expr.value.Dialect == full_dialect
+    assert expr.value._value_1 == "tns1:RuleEngine//."
+
+
+def test_topic_expression_dialect_constant_matches_onvif_spec() -> None:
+    """The default dialect is the ONVIF ConcreteSet URI verbatim."""
+    assert TopicExpression.DIALECT == ONVIF_CONCRETE_SET_DIALECT


### PR DESCRIPTION
Hey, I'll start by saying I'm new to this and I just ran into an issue where I could not control topic subscriptions, so I've tried to add it a few ways and I wanted to bring that to this PR and get some feedback.

My first attempt was to simply set the `Filter` something like
```python3
subscription_params["Filter"] = {
    "_value_1": "*",
}
```

This doesn't break, but it doesn't actually work. The actual definition can be found in the spec
```xml
<xsd:complexType name="TopicExpressionType" mixed="true">
  <xsd:simpleContent>
    <xsd:extension base="xsd:string">
      <xsd:attribute name="Dialect" type="xsd:anyURI" use="required" />
      <xsd:anyAttribute/>
    </xsd:extension>
  </xsd:simpleContent>
</xsd:complexType>
```

So I added a constructor to `types.py` but I'm not sure that's really right, and the reason is because I'm relying on the zeep client to actually build the `TopicExpressionType`. Maybe there's a better way to do this without requiring the client binding? 

But, this approach does make it easy for clients to call in, you just specify a filter as a string, and the dialect is set automatically for you. Painless, but you lose the ability to specify a different dialect (This could also be added as a parameter to the constructor too, if you'd prefer that). It also makes it a little easier to do some validation, (e.g. the `XPATH` is valid syntactically). 

Another approach would be to allow the filter to be passed in fully, and make it the callers problem to build the `TopicExpression`. Maybe it's still worthwhile to provide a constructor or utility to make life easier, but that would give callers the ability to set their own dialect and move the whole zeep client dependency coupling totally out of the manager. It's also worth noting that cameras with `FixedTopicSet = True` don't seem to actually support `XPATH`s, they expect a specific selection. If the selection is invalid, you'll get a pretty gnarly exception. In my application I use `GetEventProperties` to validate the selection, it didn't seem to be something that would really fit in the manager class, but if you wanted that as an example or something I could probably pull it together.


Let me know what you think would be the right approach or if I can make any changes, just thought it was useful to limit the subscriptions. 


I also fixed an issue with the `MINIMUM_SUBSCRIPTION_SECONDS`, I should probably make that a different PR but if you specify an interval under the 60s, the subscription won't renew in time, subsequent calls fail on connection timeouts and things are sad. I just enforced the minimum to get around this.
