### PR TITLE
ci: enable ruff flake8-bugbear (B) rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,5 +8,10 @@ plugins = ["covdefaults"]
 [tool.ruff]
 target-version = "py310"
 
+[tool.ruff.lint]
+extend-select = [
+  "B", # flake8-bugbear
+]
+
 [build-system]
 requires = ['setuptools>=65.4.1', 'wheel']

--- a/tests/test_server_disconnected_retry.py
+++ b/tests/test_server_disconnected_retry.py
@@ -288,7 +288,7 @@ async def test_no_retry_with_proper_connection_close(
         envelope = etree.Element("{http://test}TestRequest")
 
         # Make 3 requests - no retries should occur
-        for i in range(3):
+        for _ in range(3):
             result = await transport.post_xml(
                 f"{base_url}/onvif/device_service", envelope, {}
             )


### PR DESCRIPTION
## Summary

Splits the first slice off #190; enables the flake8-bugbear (B) rule group on its own so each ruff expansion lands as a small, reviewable PR.

Bugbear is a high signal group, it catches real bugs (mutable default args, unused loop variables, broad-except patterns, etc.), so it goes first.

## Changes

- `pyproject.toml`: add `[tool.ruff.lint]` with `extend-select = ["B"]`, keeping the existing E/F defaults.
- `tests/test_server_disconnected_retry.py`: rename the unused loop control variable from `i` to `_` to satisfy B007.

## Test plan

- `ruff check` clean against tracked files
- `ruff format --check` clean
- pre-commit hooks pass