### PR TITLE
ci: enable ruff flake8-datetimez (DTZ) rules

### DIFF
--- a/onvif/client.py
+++ b/onvif/client.py
@@ -542,8 +542,9 @@ class ONVIFCamera:
             cdate.Time.Hour,
             cdate.Time.Minute,
             cdate.Time.Second,
+            tzinfo=dt.timezone.utc,
         )
-        self.dt_diff = cam_date - dt.datetime.utcnow()
+        self.dt_diff = cam_date - dt.datetime.now(dt.timezone.utc)
         await devicemgmt.close()
         del self.services[devicemgmt.binding_key]
         return await self.create_devicemgmt_service()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ target-version = "py310"
 [tool.ruff.lint]
 extend-select = [
   "B", # flake8-bugbear
+  "DTZ", # flake8-datetimez
 ]
 
 [build-system]

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -51,7 +51,7 @@ def test_parse_invalid_time() -> None:
 
 
 def test_fix_datetime_missing_time() -> None:
-    assert FastDateTime().pythonvalue("2024-08-17") == datetime.datetime(
+    assert FastDateTime().pythonvalue("2024-08-17") == datetime.datetime(  # noqa: DTZ001
         2024, 8, 17, 0, 0, 0
     )
 
@@ -60,7 +60,7 @@ def test_fix_datetime_missing_t() -> None:
     assert FastDateTime().pythonvalue("2024-08-17 00:61:16Z") == datetime.datetime(
         2024, 8, 17, 1, 1, 16, tzinfo=datetime.timezone.utc
     )
-    assert FastDateTime().pythonvalue("2024-08-17 00:61:16") == datetime.datetime(
+    assert FastDateTime().pythonvalue("2024-08-17 00:61:16") == datetime.datetime(  # noqa: DTZ001
         2024, 8, 17, 1, 1, 16
     )
 
@@ -71,7 +71,7 @@ def test_fix_datetime_dash_separator() -> None:
     Regression test for
     https://github.com/openvideolibs/python-onvif-zeep-async/issues/99
     """
-    assert FastDateTime().pythonvalue("2010-01-01-00:00:00") == datetime.datetime(
+    assert FastDateTime().pythonvalue("2010-01-01-00:00:00") == datetime.datetime(  # noqa: DTZ001
         2010, 1, 1, 0, 0, 0
     )
     assert FastDateTime().pythonvalue("2010-01-01-00:00:00Z") == datetime.datetime(


### PR DESCRIPTION
## Summary

Splits the second slice off #190; enables flake8-datetimez (DTZ) so naive UTC datetime usage is caught at lint time.

For a network library that handles WS-Security timestamps and device clock skew, timezone-aware UTC is the safer default; the change is value-preserving so downstream consumers (including home-assistant's onvif integration, which never enables `adjust_time`) are unaffected.

## Changes

- `pyproject.toml`: extend-select adds `DTZ`.
- `onvif/client.py` `_adjust_time()`: build `cam_date` with `tzinfo=dt.timezone.utc` and replace `dt.datetime.utcnow()` with `dt.datetime.now(dt.timezone.utc)`; both sides remain UTC clock readings so the resulting `dt_diff` timedelta is unchanged in value and type.
- `tests/test_types.py`: three assertions get `# noqa: DTZ001`, they intentionally validate `FastDateTime`'s naive input behavior.

## Test plan

- `ruff check` clean against tracked files
- `ruff format --check` clean
- `pytest tests/` 108 passed