### PR TITLE
ci: enable ruff isort (I) rules

### DIFF
--- a/examples/events.py
+++ b/examples/events.py
@@ -1,14 +1,16 @@
 """Example to fetch pullpoint events."""
 
-from aiohttp import web
 import argparse
 import asyncio
 import datetime as dt
 import logging
-import onvif
 import os.path
 import pprint
 import sys
+
+from aiohttp import web
+
+import onvif
 
 SUBSCRIPTION_TIME = dt.timedelta(minutes=1)
 WAIT_TIME = dt.timedelta(seconds=30)

--- a/onvif/client.py
+++ b/onvif/client.py
@@ -9,19 +9,19 @@ import os.path
 from collections.abc import Callable
 from typing import Any, TypeVar
 
+import aiohttp
+import httpx
 import zeep.helpers
+from aiohttp import BasicAuth, ClientSession, DigestAuthMiddleware, TCPConnector
+from requests import Response
 from zeep.cache import SqliteCache
 from zeep.client import AsyncClient as BaseZeepAsyncClient
 from zeep.proxy import AsyncServiceProxy
 from zeep.wsdl import Document
 from zeep.wsse.username import UsernameToken
 
-import aiohttp
-import httpx
-from aiohttp import BasicAuth, ClientSession, DigestAuthMiddleware, TCPConnector
 from onvif.definition import SERVICES
 from onvif.exceptions import ONVIFAuthError, ONVIFError, ONVIFTimeoutError
-from requests import Response
 
 from .const import KEEPALIVE_EXPIRY
 from .managers import NotificationManager, PullPointManager

--- a/onvif/managers.py
+++ b/onvif/managers.py
@@ -9,11 +9,11 @@ from abc import abstractmethod
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
+import aiohttp
 from zeep.exceptions import Fault, XMLParseError, XMLSyntaxError
 from zeep.loader import parse_xml
 from zeep.wsdl.bindings.soap import SoapOperation
 
-import aiohttp
 from onvif.exceptions import ONVIFError
 
 from .settings import DEFAULT_SETTINGS

--- a/onvif/types.py
+++ b/onvif/types.py
@@ -1,9 +1,10 @@
 """ONVIF types."""
 
-from datetime import datetime, timedelta, time
+from datetime import datetime, time, timedelta
+
 import ciso8601
-from zeep.xsd.types.builtins import DateTime, treat_whitespace, Time
 import isodate
+from zeep.xsd.types.builtins import DateTime, Time, treat_whitespace
 
 
 def _try_parse_datetime(value: str) -> datetime | None:

--- a/onvif/util.py
+++ b/onvif/util.py
@@ -10,10 +10,9 @@ from functools import lru_cache, partial
 from typing import Any
 from urllib.parse import ParseResultBytes, urlparse, urlunparse
 
-from zeep.exceptions import Fault
-
 from multidict import CIMultiDict
 from yarl import URL
+from zeep.exceptions import Fault
 
 utcnow: partial[dt.datetime] = partial(dt.datetime.now, dt.timezone.utc)
 

--- a/onvif/zeep_aiohttp.py
+++ b/onvif/zeep_aiohttp.py
@@ -6,15 +6,15 @@ import asyncio
 import logging
 from typing import TYPE_CHECKING, Any
 
+import httpx
+from aiohttp import ClientResponse, ClientSession, hdrs
+from multidict import CIMultiDict
+from requests import Response
+from requests.structures import CaseInsensitiveDict
 from zeep.cache import SqliteCache
 from zeep.transports import Transport
 from zeep.utils import get_version
 from zeep.wsdl.utils import etree_to_string
-from multidict import CIMultiDict
-import httpx
-from aiohttp import ClientResponse, ClientSession, hdrs
-from requests import Response
-from requests.structures import CaseInsensitiveDict
 
 if TYPE_CHECKING:
     from lxml.etree import _Element

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ target-version = "py310"
 extend-select = [
   "B", # flake8-bugbear
   "DTZ", # flake8-datetimez
+  "I", # isort
 ]
 
 [build-system]

--- a/tests/test_hikvision_e2e.py
+++ b/tests/test_hikvision_e2e.py
@@ -16,11 +16,11 @@ from collections.abc import AsyncGenerator
 import pytest
 import pytest_asyncio
 
-import onvif
-from onvif import ONVIFCamera
-
 # fake_hikvision is a sibling test helper; pytest puts tests/ on sys.path.
 from fake_hikvision import WSSE_NS, FakeHikvisionCamera
+
+import onvif
+from onvif import ONVIFCamera
 
 WSDL_DIR = os.path.join(os.path.dirname(onvif.__file__), "wsdl")
 DIGEST_TYPE = (

--- a/tests/test_server_disconnected_retry.py
+++ b/tests/test_server_disconnected_retry.py
@@ -6,7 +6,7 @@ import asyncio
 import inspect
 import os
 from collections.abc import AsyncGenerator, Generator
-from unittest.mock import AsyncMock, Mock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import aiohttp
 import pytest

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -6,11 +6,11 @@ from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, Mock, patch
 
-import pytest_asyncio
-
 import aiohttp
 import pytest
+import pytest_asyncio
 from aioresponses import aioresponses
+
 from onvif import ONVIFCamera
 from onvif.exceptions import ONVIFAuthError, ONVIFError, ONVIFTimeoutError
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
+import datetime
 import os
 
 import pytest
 from zeep.loader import parse_xml
-import datetime
+
 from onvif.client import ONVIFCamera
 from onvif.settings import DEFAULT_SETTINGS
 from onvif.transport import ASYNC_TRANSPORT

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -4,12 +4,11 @@ import os
 
 import pytest
 from zeep.loader import parse_xml
-from onvif.util import strip_user_pass_url, obscure_user_pass_url
 
 from onvif.client import ONVIFCamera
 from onvif.settings import DEFAULT_SETTINGS
 from onvif.transport import ASYNC_TRANSPORT
-from onvif.util import normalize_url
+from onvif.util import normalize_url, obscure_user_pass_url, strip_user_pass_url
 
 PULL_POINT_RESPONSE_MISSING_URL = b'<?xml version="1.0" encoding="UTF-8"?>\n<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://www.w3.org/2003/05/soap-envelope" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:wsdd="http://schemas.xmlsoap.org/ws/2005/04/discovery" xmlns:chan="http://schemas.microsoft.com/ws/2005/02/duplex" xmlns:wsa5="http://www.w3.org/2005/08/addressing" xmlns:ns1="http://www.onvif.org/ver10/pacs" xmlns:xmime="http://tempuri.org/xmime.xsd" xmlns:xop="http://www.w3.org/2004/08/xop/include" xmlns:tt="http://www.onvif.org/ver10/schema" xmlns:wsrfbf="http://docs.oasis-open.org/wsrf/bf-2" xmlns:wstop="http://docs.oasis-open.org/wsn/t-1" xmlns:wsrfr="http://docs.oasis-open.org/wsrf/r-2" xmlns:tdn="http://www.onvif.org/ver10/network/wsdl" xmlns:tds="http://www.onvif.org/ver10/device/wsdl" xmlns:tev="http://www.onvif.org/ver10/events/wsdl" xmlns:wsnt="http://docs.oasis-open.org/wsn/b-2" xmlns:timg="http://www.onvif.org/ver20/imaging/wsdl" xmlns:tmd="http://www.onvif.org/ver10/deviceIO/wsdl" xmlns:tptz="http://www.onvif.org/ver20/ptz/wsdl" xmlns:trt="http://www.onvif.org/ver10/media/wsdl" xmlns:trv="http://www.onvif.org/ver10/receiver/wsdl" xmlns:tse="http://www.onvif.org/ver10/search/wsdl"><SOAP-ENV:Header><wsa5:MessageID>urn:uuid:76acd0bc-498e-4657-9414-b386bd4b0985</wsa5:MessageID><wsa5:To SOAP-ENV:mustUnderstand="1">http://192.168.2.18:8080/onvif/device_service</wsa5:To><wsa5:Action SOAP-ENV:mustUnderstand="1">http://www.onvif.org/ver10/events/wsdl/EventPortType/CreatePullPointSubscriptionRequest</wsa5:Action></SOAP-ENV:Header><SOAP-ENV:Body><tev:CreatePullPointSubscriptionResponse><tev:SubscriptionReference><wsa5:Address/></tev:SubscriptionReference><wsnt:CurrentTime>1970-01-01T00:00:00Z</wsnt:CurrentTime><wsnt:TerminationTime>1970-01-01T00:00:00Z</wsnt:TerminationTime></tev:CreatePullPointSubscriptionResponse></SOAP-ENV:Body></SOAP-ENV:Envelope>\r\n'
 _WSDL_PATH = os.path.join(os.path.dirname(os.path.dirname(__file__)), "onvif", "wsdl")

--- a/tests/test_xaddrs.py
+++ b/tests/test_xaddrs.py
@@ -7,11 +7,11 @@ from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, Mock, patch
 
+import pytest
 import pytest_asyncio
 from zeep.exceptions import Fault
 
 import onvif
-import pytest
 from onvif import ONVIFCamera
 from onvif.exceptions import ONVIFError
 

--- a/tests/test_zeep_transport.py
+++ b/tests/test_zeep_transport.py
@@ -8,8 +8,9 @@ import httpx
 import pytest
 from lxml import etree
 from multidict import CIMultiDict
-from onvif.zeep_aiohttp import AIOHTTPTransport
 from requests import Response as RequestsResponse
+
+from onvif.zeep_aiohttp import AIOHTTPTransport
 
 
 def create_mock_session(timeout=None):


### PR DESCRIPTION
## Summary

Third slice off #190; enables the I (isort) rule group so import order stays consistent and future PRs don't carry stray import churn.

Pure mechanical fix via ruff --fix; default isort settings, no behavior changes.

## Changes

- `pyproject.toml`: extend-select adds `I`.
- 13 files reorganized by ruff's isort auto-fix (onvif/, tests/, examples/), grouping stdlib, third-party, first-party, and local imports.

## Test plan

- `ruff check` clean
- `ruff format --check` clean
- `pytest tests/` 149 passed