### PR TITLE
ci: enable ruff flake8-type-checking (TC) rules

### DIFF
--- a/onvif/client.py
+++ b/onvif/client.py
@@ -6,14 +6,11 @@ import asyncio
 import datetime as dt
 import logging
 import os.path
-from collections.abc import Callable
-from typing import Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar
 
 import aiohttp
-import httpx
 import zeep.helpers
 from aiohttp import BasicAuth, ClientSession, DigestAuthMiddleware, TCPConnector
-from requests import Response
 from zeep.cache import SqliteCache
 from zeep.client import AsyncClient as BaseZeepAsyncClient
 from zeep.proxy import AsyncServiceProxy
@@ -39,6 +36,12 @@ from .util import (
 from .wrappers import retry_connection_error
 from .wsa import WsAddressingIfMissingPlugin
 from .zeep_aiohttp import AIOHTTPTransport
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    import httpx
+    from requests import Response
 
 logger = logging.getLogger("onvif")
 logging.basicConfig(level=logging.INFO)

--- a/onvif/managers.py
+++ b/onvif/managers.py
@@ -6,13 +6,11 @@ import asyncio
 import datetime as dt
 import logging
 from abc import abstractmethod
-from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 import aiohttp
 from zeep.exceptions import Fault, XMLParseError, XMLSyntaxError
 from zeep.loader import parse_xml
-from zeep.wsdl.bindings.soap import SoapOperation
 
 from onvif.exceptions import ONVIFError
 
@@ -36,6 +34,10 @@ SUBSCRIPTION_RESTART_INTERVAL_ON_ERROR = dt.timedelta(seconds=40)
 MINIMUM_SUBSCRIPTION_SECONDS = 60.0
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from zeep.wsdl.bindings.soap import SoapOperation
+
     from onvif.client import ONVIFCamera, ONVIFService
 
 

--- a/onvif/wrappers.py
+++ b/onvif/wrappers.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from collections.abc import Awaitable, Callable
-from typing import ParamSpec, TypeVar
+from typing import TYPE_CHECKING, ParamSpec, TypeVar
 
 import aiohttp
 
 from .const import BACKOFF_TIME, DEFAULT_ATTEMPTS
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
 
 P = ParamSpec("P")
 T = TypeVar("T")

--- a/onvif/zeep_aiohttp.py
+++ b/onvif/zeep_aiohttp.py
@@ -8,16 +8,16 @@ from typing import TYPE_CHECKING, Any
 
 import httpx
 from aiohttp import ClientResponse, ClientSession, hdrs
-from multidict import CIMultiDict
 from requests import Response
 from requests.structures import CaseInsensitiveDict
-from zeep.cache import SqliteCache
 from zeep.transports import Transport
 from zeep.utils import get_version
 from zeep.wsdl.utils import etree_to_string
 
 if TYPE_CHECKING:
     from lxml.etree import _Element
+    from multidict import CIMultiDict
+    from zeep.cache import SqliteCache
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ extend-select = [
   "B", # flake8-bugbear
   "DTZ", # flake8-datetimez
   "I", # isort
+  "TC", # flake8-type-checking
 ]
 
 [build-system]

--- a/tests/test_hikvision_e2e.py
+++ b/tests/test_hikvision_e2e.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import datetime as dt
 import os
-from collections.abc import AsyncGenerator
+from typing import TYPE_CHECKING
 
 import pytest
 import pytest_asyncio
@@ -21,6 +21,9 @@ from fake_hikvision import WSSE_NS, FakeHikvisionCamera
 
 import onvif
 from onvif import ONVIFCamera
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
 
 WSDL_DIR = os.path.join(os.path.dirname(onvif.__file__), "wsdl")
 DIGEST_TYPE = (

--- a/tests/test_server_disconnected_retry.py
+++ b/tests/test_server_disconnected_retry.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import inspect
 import os
-from collections.abc import AsyncGenerator, Generator
+from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import aiohttp
@@ -17,6 +17,9 @@ from lxml import etree
 import onvif
 from onvif.client import AsyncTransportProtocolErrorHandler, ONVIFService
 from onvif.zeep_aiohttp import AIOHTTPTransport
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator, Generator
 
 
 @pytest.fixture

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, Mock, patch
 
 import aiohttp
@@ -13,6 +13,9 @@ from aioresponses import aioresponses
 
 from onvif import ONVIFCamera
 from onvif.exceptions import ONVIFAuthError, ONVIFError, ONVIFTimeoutError
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
 
 
 @pytest.fixture

--- a/tests/test_xaddrs.py
+++ b/tests/test_xaddrs.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import os
-from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -14,6 +14,9 @@ from zeep.exceptions import Fault
 import onvif
 from onvif import ONVIFCamera
 from onvif.exceptions import ONVIFError
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
 
 WSDL_DIR = os.path.join(os.path.dirname(onvif.__file__), "wsdl")
 


### PR DESCRIPTION
## Summary

Fourth slice off #190; enables TC so type-only imports stay out of the runtime import graph.

This trims the cost of importing the package, which matters for downstream consumers that pay the import tax at startup (e.g. home-assistant boot).

## Changes

- `pyproject.toml`: extend-select adds `TC`.
- Moves 14 type-only imports under `if TYPE_CHECKING:` blocks across 8 files:
  - `onvif/client.py`: `Callable`, `httpx`, `requests.Response`
  - `onvif/managers.py`: `Callable`, `SoapOperation`
  - `onvif/wrappers.py`: `Awaitable`, `Callable`
  - `onvif/zeep_aiohttp.py`: `CIMultiDict`, `SqliteCache`
  - 4 test files: `AsyncGenerator`, `Generator`

All affected modules already use `from __future__ import annotations`, so annotations are forward references; nothing is resolved at runtime, no behavior change.

## Test plan

- `ruff check` clean
- `ruff format --check` clean
- `pytest tests/` 149 passed
- Smoke import test mirroring home-assistant's import set passes