### PR TITLE
ci: enable ruff flake8-errmsg (EM) rules

### DIFF
--- a/onvif/client.py
+++ b/onvif/client.py
@@ -196,13 +196,11 @@ def handle_snapshot_errors(func: Callable[..., _T]) -> Callable[..., _T]:
         try:
             return await func(self, uri, *args, **kwargs)
         except TimeoutError as error:
-            raise ONVIFTimeoutError(
-                f"Timed out fetching {obscure_user_pass_url(uri)}: {error}"
-            ) from error
+            msg = f"Timed out fetching {obscure_user_pass_url(uri)}: {error}"
+            raise ONVIFTimeoutError(msg) from error
         except aiohttp.ClientError as error:
-            raise ONVIFError(
-                f"Error fetching {obscure_user_pass_url(uri)}: {error}"
-            ) from error
+            msg = f"Error fetching {obscure_user_pass_url(uri)}: {error}"
+            raise ONVIFError(msg) from error
 
     return wrapper
 
@@ -224,10 +222,11 @@ class ZeepAsyncClient(BaseZeepAsyncClient):
         try:
             binding = self.wsdl.bindings[binding_name]
         except KeyError:
-            raise ValueError(
+            msg = (
                 f"No binding found with the given QName. Available bindings "
                 f"are: {', '.join(self.wsdl.bindings.keys())}"
-            ) from None
+            )
+            raise ValueError(msg) from None
         return AsyncServiceProxy(self, binding, address=address)
 
 
@@ -278,7 +277,8 @@ class ONVIFService:
         write_timeout: int | None = None,
     ) -> None:
         if not path_isfile(url):
-            raise ONVIFError(f"{url} doesn`t exist!")
+            msg = f"{url} doesn`t exist!"
+            raise ONVIFError(msg)
 
         self.url = url
         self.xaddr = xaddr
@@ -770,7 +770,8 @@ class ONVIFCamera:
             content = await self._try_read_snapshot_content(uri, response)
 
         if response.status == 401:
-            raise ONVIFAuthError(f"Failed to authenticate to {uri}")
+            msg = f"Failed to authenticate to {uri}"
+            raise ONVIFAuthError(msg)
 
         if response.status < 300:
             return content
@@ -801,7 +802,8 @@ class ONVIFCamera:
         """Returns xaddr and wsdl of specified service"""
         # Check if the service is supported
         if name not in SERVICES:
-            raise ONVIFError(f"Unknown service {name}")
+            msg = f"Unknown service {name}"
+            raise ONVIFError(msg)
         wsdl_file = SERVICES[name]["wsdl"]
         namespace = SERVICES[name]["ns"]
 
@@ -812,7 +814,8 @@ class ONVIFCamera:
 
         wsdlpath = os.path.join(self.wsdl_dir, wsdl_file)
         if not path_isfile(wsdlpath):
-            raise ONVIFError(f"No such file: {wsdlpath}")
+            msg = f"No such file: {wsdlpath}"
+            raise ONVIFError(msg)
 
         # XAddr for devicemgmt is fixed:
         if name == "devicemgmt":
@@ -827,9 +830,8 @@ class ONVIFCamera:
         # Get other XAddr
         xaddr = self.xaddrs.get(namespace)
         if not xaddr:
-            raise ONVIFError(
-                f"Device doesn`t support service: {name} with namespace {namespace}"
-            )
+            msg = f"Device doesn`t support service: {name} with namespace {namespace}"
+            raise ONVIFError(msg)
 
         return xaddr, wsdlpath, binding_name
 

--- a/onvif/transport.py
+++ b/onvif/transport.py
@@ -15,7 +15,8 @@ class AsyncSafeTransport(Transport):
     def load(self, url: str) -> None:
         """Load the given XML document."""
         if not path_isfile(url):
-            raise RuntimeError(f"Loading {url} is not supported in async mode")
+            msg = f"Loading {url} is not supported in async mode"
+            raise RuntimeError(msg)
         with open(os.path.expanduser(url), "rb") as fh:
             return fh.read()
 

--- a/onvif/zeep_aiohttp.py
+++ b/onvif/zeep_aiohttp.py
@@ -168,9 +168,11 @@ class AIOHTTPTransport(Transport):
             return response, content
         except RuntimeError as exc:
             # Handle RuntimeError which may occur if the session is closed
-            raise RuntimeError(f"Failed to post to {address}: {exc}") from exc
+            msg = f"Failed to post to {address}: {exc}"
+            raise RuntimeError(msg) from exc
         except TimeoutError as exc:
-            raise TimeoutError(f"Request to {address} timed out") from exc
+            msg = f"Request to {address} timed out"
+            raise TimeoutError(msg) from exc
 
     async def post(
         self, address: str, message: str, headers: dict[str, str]
@@ -256,10 +258,12 @@ class AIOHTTPTransport(Transport):
             return self._aiohttp_to_requests_response(response, content)
         except RuntimeError as exc:
             # Handle RuntimeError which may occur if the session is closed
-            raise RuntimeError(f"Failed to get from {address}: {exc}") from exc
+            msg = f"Failed to get from {address}: {exc}"
+            raise RuntimeError(msg) from exc
 
         except TimeoutError as exc:
-            raise TimeoutError(f"Request to {address} timed out") from exc
+            msg = f"Request to {address} timed out"
+            raise TimeoutError(msg) from exc
 
     def load(self, url: str) -> bytes:
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ target-version = "py310"
 extend-select = [
   "B", # flake8-bugbear
   "DTZ", # flake8-datetimez
+  "EM", # flake8-errmsg
   "I", # isort
   "TC", # flake8-type-checking
 ]

--- a/tests/test_xaddrs.py
+++ b/tests/test_xaddrs.py
@@ -217,7 +217,8 @@ async def test_update_xaddrs_survives_unserializable_capabilities(
 
     class _Unserializable(dict):
         def __iter__(self):
-            raise ValueError("cannot serialize")
+            msg = "cannot serialize"
+            raise ValueError(msg)
 
     bad_caps = {"Extension": _Unserializable()}
     devicemgmt = _mock_devicemgmt(get_services=AsyncMock(side_effect=Fault("x")))


### PR DESCRIPTION
## Summary

Fifth slice off #190; enables EM so exception messages are assigned to a local before being raised.

This keeps the message literal out of the traceback header, makes the raise site easier to read, and forces the f-string to be evaluated in a named expression rather than buried inline.

## Changes

- `pyproject.toml`: extend-select adds `EM`.
- Pure mechanical auto-fix (with --unsafe-fixes) across 14 sites in 4 files:
  - `onvif/client.py` (8), `onvif/zeep_aiohttp.py` (4), `onvif/transport.py` (1), `tests/test_xaddrs.py` (1).
- Each `raise X(literal)` becomes `msg = literal; raise X(msg)`; exception type and message text are unchanged.

## Test plan

- `ruff check` clean
- `ruff format --check` clean
- `pytest tests/` 149 passed