### PR TITLE
ci: enable ruff flake8-simplify (SIM) rules

### DIFF
--- a/onvif/client.py
+++ b/onvif/client.py
@@ -380,10 +380,7 @@ class ONVIFService:
             def wrapped(params=None):
                 def call(params=None):
                     # No params
-                    if params is None:
-                        params = {}
-                    else:
-                        params = ONVIFService.to_dict(params)
+                    params = {} if params is None else ONVIFService.to_dict(params)
                     try:
                         ret = func(**params)
                     except TypeError:

--- a/onvif/zeep_aiohttp.py
+++ b/onvif/zeep_aiohttp.py
@@ -142,10 +142,7 @@ class AIOHTTPTransport(Transport):
         headers.setdefault("Content-Type", 'text/xml; charset="utf-8"')
 
         # Handle both str and bytes
-        if isinstance(message, str):
-            data = message.encode("utf-8")
-        else:
-            data = message
+        data = message.encode("utf-8") if isinstance(message, str) else message
 
         try:
             response = await self.session.post(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ extend-select = [
   "DTZ", # flake8-datetimez
   "EM", # flake8-errmsg
   "I", # isort
+  "SIM", # flake8-simplify
   "TC", # flake8-type-checking
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,10 @@ from setuptools import find_packages, setup
 
 here = os.path.abspath(os.path.dirname(__file__))
 version_path = os.path.join(here, "onvif/version.txt")
-version = open(version_path).read().strip()
+with open(version_path) as version_file:
+    version = version_file.read().strip()
+with open("README.rst") as readme_file:
+    long_description = readme_file.read()
 
 requires = [
     "aiohttp>=3.12.9",
@@ -41,7 +44,7 @@ setup(
     name="onvif-zeep-async",
     version=version,
     description="Async Python Client for ONVIF Camera",
-    long_description=open("README.rst").read(),
+    long_description=long_description,
     author="Cherish Chen",
     author_email="sinchb128@gmail.com",
     maintainer="sinchb",

--- a/tests/test_zeep_transport.py
+++ b/tests/test_zeep_transport.py
@@ -541,18 +541,20 @@ def test_sync_load_creates_new_loop():
     mock_response.content = b"<wsdl/>"
 
     # This should work even if there's already an event loop
-    with patch.object(transport, "get", new=AsyncMock(return_value=mock_response)):
-        with patch("asyncio.new_event_loop") as mock_new_loop:
-            mock_loop = Mock()
-            mock_loop.run_until_complete.return_value = mock_response
-            mock_new_loop.return_value = mock_loop
+    with (
+        patch.object(transport, "get", new=AsyncMock(return_value=mock_response)),
+        patch("asyncio.new_event_loop") as mock_new_loop,
+    ):
+        mock_loop = Mock()
+        mock_loop.run_until_complete.return_value = mock_response
+        mock_new_loop.return_value = mock_loop
 
-            result = transport.load("http://example.com/wsdl")
+        result = transport.load("http://example.com/wsdl")
 
-            # Should have created new loop
-            mock_new_loop.assert_called_once()
-            mock_loop.close.assert_called_once()
-            assert result == b"<wsdl/>"
+        # Should have created new loop
+        mock_new_loop.assert_called_once()
+        mock_loop.close.assert_called_once()
+        assert result == b"<wsdl/>"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Sixth slice off #190; enables SIM so future PRs can't regress on a handful of common readability anti-patterns.

Pure mechanical cleanup; no behavior change.

## Changes

- `pyproject.toml`: extend-select adds `SIM`.
- 5 fixes across 4 files:
  - `onvif/client.py`, `onvif/zeep_aiohttp.py`: collapse if/else assignment into a ternary (SIM108).
  - `setup.py`: read version.txt and README.rst inside `with` blocks (SIM115).
  - `tests/test_zeep_transport.py`: combine two nested `with` statements into a single parenthesized form (SIM117).

## Test plan

- `ruff check` clean
- `ruff format --check` clean
- `pytest tests/` 149 passed