### PR TITLE
ci: enable ruff RUF rule group

### DIFF
--- a/onvif/__init__.py
+++ b/onvif/__init__.py
@@ -21,12 +21,12 @@ def zeep_pythonvalue(self, xmlvalue):
 zeep.xsd.simple.AnySimpleType.pythonvalue = zeep_pythonvalue
 
 __all__ = (
-    "ONVIFService",
+    "ERR_ONVIF_BUILD",
+    "ERR_ONVIF_PROTOCOL",
+    "ERR_ONVIF_UNKNOWN",
+    "ERR_ONVIF_WSDL",
+    "SERVICES",
     "ONVIFCamera",
     "ONVIFError",
-    "ERR_ONVIF_UNKNOWN",
-    "ERR_ONVIF_PROTOCOL",
-    "ERR_ONVIF_WSDL",
-    "ERR_ONVIF_BUILD",
-    "SERVICES",
+    "ONVIFService",
 )

--- a/onvif/wsa.py
+++ b/onvif/wsa.py
@@ -1,4 +1,5 @@
 import uuid
+from typing import ClassVar
 
 from lxml import etree
 from lxml.builder import ElementMaker
@@ -10,9 +11,9 @@ WSA = ElementMaker(namespace=ns.WSA, nsmap={"wsa": ns.WSA})
 
 
 class WsAddressingIfMissingPlugin(Plugin):
-    nsmap = {"wsa": ns.WSA}
+    nsmap: ClassVar[dict[str, str]] = {"wsa": ns.WSA}
 
-    def __init__(self, address_url: str = None):
+    def __init__(self, address_url: str | None = None):
         self.address_url = address_url
 
     def egress(self, envelope, http_headers, operation, binding_options):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,8 +14,15 @@ extend-select = [
   "DTZ", # flake8-datetimez
   "EM", # flake8-errmsg
   "I", # isort
+  "RUF", # ruff-specific
   "SIM", # flake8-simplify
   "TC", # flake8-type-checking
+]
+ignore = [
+  # Re-enable once the rules these noqa directives reference (S, A, F841) are
+  # selected; until then RUF100 would force deleting noqa comments we'll need
+  # back.
+  "RUF100",
 ]
 
 [build-system]

--- a/tests/test_zeep_transport.py
+++ b/tests/test_zeep_transport.py
@@ -185,7 +185,7 @@ async def test_timeout_handling():
 
     transport.session = mock_session
 
-    with pytest.raises(TimeoutError, match="Request to .* timed out"):
+    with pytest.raises(TimeoutError, match=r"Request to .* timed out"):
         await transport.post(
             "http://example.com/service", "<request>test</request>", {}
         )


### PR DESCRIPTION
## Summary

Seventh slice off #190; enables the RUF (ruff-specific) rule group, with RUF100 temporarily ignored.

The bug-class wins here are RUF012 (mutable class default) and RUF013 (implicit Optional) on the WS-Addressing plugin; RUF022 sorts the package's __all__, and RUF043 marks a regex pattern as raw.

RUF100 is ignored for now because several test files carry noqa comments for rules not yet selected (S, A, F841); once those rule groups land, RUF100 can come back without churning noqa back and forth.

## Changes

- `pyproject.toml`: extend-select adds `RUF`, ignore adds `RUF100` with a comment explaining the deferral.
- `onvif/__init__.py`: sort the __all__ tuple (RUF022).
- `onvif/wsa.py`: annotate `WsAddressingIfMissingPlugin.nsmap` with `typing.ClassVar` (RUF012); replace the implicit Optional on `address_url` with `str | None` (RUF013).
- `tests/test_zeep_transport.py`: raw-string the `pytest.raises` match pattern (RUF043).

## Test plan

- `ruff check` clean
- `ruff format --check` clean
- `pytest tests/` 149 passed