### PR TITLE
ci: enable ruff flake8-bandit (S) rules

### DIFF
--- a/onvif/managers.py
+++ b/onvif/managers.py
@@ -84,7 +84,7 @@ class BaseManager:
         """Stop the manager."""
         logger.debug("%s: Stop the notification manager", self._device.host)
         self._cancel_renewals()
-        assert self._subscription, "Call start first"
+        assert self._subscription, "Call start first"  # noqa: S101
         await self._subscription.Unsubscribe()
 
     async def shutdown(self) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,14 +15,22 @@ extend-select = [
   "EM", # flake8-errmsg
   "I", # isort
   "RUF", # ruff-specific
+  "S", # flake8-bandit
   "SIM", # flake8-simplify
   "TC", # flake8-type-checking
 ]
 ignore = [
-  # Re-enable once the rules these noqa directives reference (S, A, F841) are
+  # Re-enable once the rules these noqa directives reference (A, F841) are
   # selected; until then RUF100 would force deleting noqa comments we'll need
   # back.
   "RUF100",
+]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**" = [
+  "S101", # asserts in tests
+  "S105", # hardcoded password strings
+  "S106", # hardcoded passwords passed as args
 ]
 
 [build-system]

--- a/tests/test_xaddrs.py
+++ b/tests/test_xaddrs.py
@@ -60,7 +60,7 @@ def _services_response() -> list[Mock]:
 
 @asynccontextmanager
 async def _create_camera() -> AsyncGenerator[ONVIFCamera]:
-    cam = ONVIFCamera("192.168.1.100", 80, "admin", "password", wsdl_dir=WSDL_DIR)  # noqa: S106
+    cam = ONVIFCamera("192.168.1.100", 80, "admin", "password", wsdl_dir=WSDL_DIR)
     try:
         yield cam
     finally:
@@ -273,7 +273,7 @@ async def test_update_xaddrs_adjust_time_retries_with_auth_on_fault() -> None:
         "192.168.1.100",
         80,
         "admin",
-        "password",  # noqa: S106
+        "password",
         wsdl_dir=WSDL_DIR,
         adjust_time=True,
     )


### PR DESCRIPTION
## Summary

Eighth slice off #190; enables S so security smells surface at lint time, while keeping the noisy test-only rules off for tests/**.

S is high value: it catches things like raw SQL, unsafe yaml/pickle, weak hash usage, hardcoded credentials in non-test code, and unvalidated subprocess args. None of those fire today, but having the group selected catches future regressions.

## Changes

- `pyproject.toml`: extend-select adds `S`. New per-file ignore for `tests/**` covers `S101` (assert), `S105` (hardcoded password strings), `S106` (hardcoded passwords as args); all unavoidable in this test suite.
- `onvif/managers.py`: the precondition assert in `NotificationManager.stop()` gets `# noqa: S101` since it is an internal invariant.
- `tests/test_xaddrs.py`: drops two now-redundant `# noqa: S106` markers that the per-file ignore makes obsolete.

The earlier RUF100 ignore comment is updated to drop the S reference, since S has landed.

## Test plan

- `ruff check` clean
- `ruff format --check` clean
- `pytest tests/` 149 passed