### PR TITLE
Warm wsdl directory cache off the event loop in create_onvif_service

### DIFF
--- a/onvif/client.py
+++ b/onvif/client.py
@@ -49,17 +49,27 @@ logging.getLogger("zeep.client").setLevel(logging.CRITICAL)
 
 _SENTINEL = object()
 _WSDL_PATH = os.path.join(os.path.dirname(os.path.dirname(__file__)), "wsdl")
-# Names of wsdl files already confirmed to exist, keyed by wsdl_dir. Populated
-# lazily off the event loop on first use so the os.listdir stays out of the
-# asyncio path.
-_WSDL_DIR_FILES: dict[str, frozenset[str]] = {}
+# Names of regular files in each wsdl_dir, populated lazily off the event loop
+# on first use so the directory scan stays out of the asyncio path. None means
+# the cache could not be built and callers should fall back to path_isfile.
+_WSDL_DIR_FILES: dict[str, frozenset[str] | None] = {}
 
 
-def _list_wsdl_dir(wsdl_dir: str) -> frozenset[str]:
+def _list_wsdl_dir(wsdl_dir: str) -> frozenset[str] | None:
+    """Return the set of regular file names in wsdl_dir.
+
+    Returns an empty frozenset if the directory itself does not exist (then
+    every wsdl lookup correctly fails); returns None on any other OSError so
+    callers fall back to path_isfile rather than treating a permissions or
+    I/O failure as "wsdl not found".
+    """
     try:
-        return frozenset(os.listdir(wsdl_dir))
-    except OSError:
+        with os.scandir(wsdl_dir) as it:
+            return frozenset(entry.name for entry in it if entry.is_file())
+    except FileNotFoundError:
         return frozenset()
+    except OSError:
+        return None
 
 
 _DEFAULT_TIMEOUT = 90

--- a/onvif/client.py
+++ b/onvif/client.py
@@ -49,6 +49,19 @@ logging.getLogger("zeep.client").setLevel(logging.CRITICAL)
 
 _SENTINEL = object()
 _WSDL_PATH = os.path.join(os.path.dirname(os.path.dirname(__file__)), "wsdl")
+# Names of wsdl files already confirmed to exist, keyed by wsdl_dir. Populated
+# lazily off the event loop on first use so the os.listdir stays out of the
+# asyncio path.
+_WSDL_DIR_FILES: dict[str, frozenset[str]] = {}
+
+
+def _list_wsdl_dir(wsdl_dir: str) -> frozenset[str]:
+    try:
+        return frozenset(os.listdir(wsdl_dir))
+    except OSError:
+        return frozenset()
+
+
 _DEFAULT_TIMEOUT = 90
 _PULLPOINT_TIMEOUT = 90
 _CONNECT_TIMEOUT = 30
@@ -276,7 +289,12 @@ class ONVIFService:
         read_timeout: int | None = None,
         write_timeout: int | None = None,
     ) -> None:
-        if not path_isfile(url):
+        wsdl_dir, wsdl_name = os.path.split(url)
+        cached_files = _WSDL_DIR_FILES.get(wsdl_dir)
+        exists = (
+            wsdl_name in cached_files if cached_files is not None else path_isfile(url)
+        )
+        if not exists:
             msg = f"{url} doesn`t exist!"
             raise ONVIFError(msg)
 
@@ -810,7 +828,13 @@ class ONVIFCamera:
             namespace += "/" + port_type
 
         wsdlpath = os.path.join(self.wsdl_dir, wsdl_file)
-        if not path_isfile(wsdlpath):
+        cached_files = _WSDL_DIR_FILES.get(self.wsdl_dir)
+        exists = (
+            wsdl_file in cached_files
+            if cached_files is not None
+            else path_isfile(wsdlpath)
+        )
+        if not exists:
             msg = f"No such file: {wsdlpath}"
             raise ONVIFError(msg)
 
@@ -844,6 +868,15 @@ class ONVIFCamera:
         # Don't re-create bindings if the xaddr remains the same.
         # The xaddr can change when a new PullPointSubscription is created.
         binding_key = (name, port_type)
+
+        # The first call for a given wsdl_dir does a single os.listdir off the
+        # event loop and caches the result, so get_definition and
+        # ONVIFService.__init__ can answer "does this wsdl exist" without
+        # blocking I/O.
+        if self.wsdl_dir not in _WSDL_DIR_FILES:
+            _WSDL_DIR_FILES[self.wsdl_dir] = await asyncio.to_thread(
+                _list_wsdl_dir, self.wsdl_dir
+            )
 
         xaddr, wsdl_file, binding_name = self.get_definition(name, port_type)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,27 +16,10 @@ if TYPE_CHECKING:
 
 _KNOWN_BLOCKING: frozenset[str] = frozenset(
     {
-        "tests/test_hikvision_e2e.py::test_get_device_information",
-        "tests/test_hikvision_e2e.py::test_update_xaddrs_discovers_services_via_get_services",
-        "tests/test_hikvision_e2e.py::test_update_xaddrs_falls_back_to_capabilities_when_get_services_broken",
-        "tests/test_hikvision_e2e.py::test_get_capabilities_returns_dict",
-        "tests/test_hikvision_e2e.py::test_get_capabilities_adjusts_time_when_called_before_update_xaddrs",
-        "tests/test_hikvision_e2e.py::test_get_capabilities_reuses_dt_diff_from_update_xaddrs",
-        "tests/test_hikvision_e2e.py::test_get_system_date_and_time",
-        "tests/test_hikvision_e2e.py::test_media_snapshot_uri",
-        "tests/test_hikvision_e2e.py::test_requests_use_digest_auth_with_zulu_timestamp",
-        "tests/test_hikvision_e2e.py::test_plaintext_auth_when_encryption_disabled",
-        "tests/test_hikvision_e2e.py::test_pullpoint_subscription_parses_hikvision_dash_timestamps",
-        "tests/test_hikvision_e2e.py::test_broken_relative_time_detection_from_pullpoint",
-        "tests/test_hikvision_e2e.py::test_camera_rejecting_unauthenticated_requests",
         "tests/test_server_disconnected_retry.py::test_multiple_sequential_requests_with_disconnects",
-        "tests/test_server_disconnected_retry.py::test_onvif_service_retries_on_server_disconnect[True]",
         "tests/test_server_disconnected_retry.py::test_onvif_service_retries_on_server_disconnect[False]",
         "tests/test_types.py::test_parse_invalid_dt",
         "tests/test_util.py::test_normalize_url_with_missing_url",
-        "tests/test_xaddrs.py::test_get_definition_resolves_recording_after_update",
-        "tests/test_xaddrs.py::test_update_xaddrs_falls_back_when_get_services_unsupported[error0]",
-        "tests/test_xaddrs.py::test_update_xaddrs_falls_back_when_get_services_unsupported[error1]",
     }
 )
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -20,7 +20,7 @@ import pytest
 
 import onvif.client
 from onvif import ONVIFCamera
-from onvif.client import ONVIFService, ZeepAsyncClient
+from onvif.client import ONVIFService, ZeepAsyncClient, _list_wsdl_dir
 from onvif.exceptions import ONVIFError
 
 if TYPE_CHECKING:
@@ -46,6 +46,35 @@ async def create_test_camera(
         yield cam
     finally:
         await cam.close()
+
+
+# --------------------------------------------------------------------------
+# _list_wsdl_dir
+# --------------------------------------------------------------------------
+
+
+def test_list_wsdl_dir_returns_regular_files() -> None:
+    """The bundled WSDL directory yields the wsdl file names as a set."""
+    files = _list_wsdl_dir(_REAL_WSDL_DIR)
+    assert files is not None
+    assert "devicemgmt.wsdl" in files
+
+
+def test_list_wsdl_dir_missing_returns_empty() -> None:
+    """A nonexistent directory yields an empty set so lookups fail cleanly."""
+    assert _list_wsdl_dir("/definitely/not/a/real/wsdl/dir") == frozenset()
+
+
+def test_list_wsdl_dir_unreadable_returns_none(tmp_path) -> None:
+    """A directory that scandir cannot read returns None to trigger fallback."""
+
+    msg = "blocked"
+
+    def _raise_permission(*_args: object, **_kwargs: object) -> None:
+        raise PermissionError(msg)
+
+    with patch("onvif.client.os.scandir", _raise_permission):
+        assert _list_wsdl_dir(str(tmp_path)) is None
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
Follow up to #201; tests under create_onvif_service tripped blockbuster on the os.stat inside path_isfile. The first call per wsdl_dir now does a single os.listdir via asyncio.to_thread and caches the filename set, so get_definition and ONVIFService.__init__ resolve existence in memory without blocking the loop.