### PR TITLE
ci: enable ruff pylint (PL) rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,12 +14,19 @@ extend-select = [
   "DTZ", # flake8-datetimez
   "EM", # flake8-errmsg
   "I", # isort
+  "PL", # pylint
   "RUF", # ruff-specific
   "S", # flake8-bandit
   "SIM", # flake8-simplify
   "TC", # flake8-type-checking
 ]
 ignore = [
+  "PLR0911", # too many return statements
+  "PLR0912", # too many branches
+  "PLR0913", # too many arguments
+  "PLR0915", # too many statements
+  "PLR2004", # magic value used in comparison
+  "PLW2901", # loop variable overwritten
   # Re-enable once the rules these noqa directives reference (A, F841) are
   # selected; until then RUF100 would force deleting noqa comments we'll need
   # back.

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, Mock, patch
 import aiohttp
 import pytest
 import pytest_asyncio
+import zeep.exceptions
 from aioresponses import aioresponses
 
 from onvif import ONVIFCamera
@@ -204,8 +205,6 @@ async def test_get_snapshot_no_uri_available(camera: ONVIFCamera) -> None:
     ) as mock_media:
         mock_service = Mock()
         mock_service.create_type = Mock(return_value=Mock())
-
-        import zeep.exceptions
 
         mock_service.GetSnapshotUri = AsyncMock(
             side_effect=zeep.exceptions.Fault("Snapshot not supported")

--- a/tests/test_zeep_transport.py
+++ b/tests/test_zeep_transport.py
@@ -429,9 +429,7 @@ async def test_cookies_in_httpx_response():
     # Mock cookies
     mock_cookie = Mock()
     mock_cookie.value = "abc123"
-    mock_cookie.get.side_effect = lambda k: {"domain": ".example.com", "path": "/"}.get(
-        k
-    )
+    mock_cookie.get.side_effect = {"domain": ".example.com", "path": "/"}.get
 
     mock_cookies = Mock()
     mock_cookies.items.return_value = [("session", mock_cookie)]


### PR DESCRIPTION
## Summary

Ninth slice off #190; enables PL, with the standard ignores for cosmetic complexity counters so refactors aren't gated on metric thresholds.

PL covers convention, refactor, and warning subcategories from pylint; after the ignores, two real violations remain and both are fixed.

## Changes

- `pyproject.toml`: extend-select adds `PL`. Adds ignores `PLR0911`, `PLR0912`, `PLR0913`, `PLR0915`, `PLR2004`, `PLW2901` (too-many-* / magic-value-comparison / loop-var-overwritten).
- `tests/test_snapshot.py`: lift the late `import zeep.exceptions` to the top of the file (PLC0415).
- `tests/test_zeep_transport.py`: drop the unnecessary lambda around `dict.get`; bind the bound method directly to `side_effect` (PLW0108).

## Test plan

- `ruff check` clean
- `ruff format --check` clean
- `pytest tests/` 149 passed