### PR TITLE
ci: enable ruff flake8-print (T20) rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ extend-select = [
   "RUF", # ruff-specific
   "S", # flake8-bandit
   "SIM", # flake8-simplify
+  "T20", # flake8-print
   "TC", # flake8-type-checking
 ]
 ignore = [
@@ -38,6 +39,9 @@ ignore = [
   "S101", # asserts in tests
   "S105", # hardcoded password strings
   "S106", # hardcoded passwords passed as args
+]
+"examples/**" = [
+  "T20", # example scripts legitimately print to the console
 ]
 
 [build-system]


### PR DESCRIPTION
## Summary

Tenth slice off #190; enables T20 so stray print() or pprint() in production code gets flagged at lint time.

Pure config change; no production code currently violates T20.

## Changes

- `pyproject.toml`: extend-select adds `T20`. New per-file ignore for `examples/**` since example scripts legitimately print to the console.

## Test plan

- `ruff check` clean
- `ruff format --check` clean
- `pytest tests/` 180 passed