### PR TITLE
ci: enable ruff tryceratops (TRY) rules

### DIFF
--- a/onvif/managers.py
+++ b/onvif/managers.py
@@ -283,8 +283,8 @@ class NotificationManager(BaseManager):
                     ASYNC_TRANSPORT,
                     settings=DEFAULT_SETTINGS,
                 )
-            except XMLSyntaxError as exc:
-                logger.error("Received invalid XML: %s (%s)", exc, content)
+            except XMLSyntaxError:
+                logger.exception("Received invalid XML: (%s)", content)
                 return None
         return self._operation.process_reply(envelope)
 

--- a/onvif/zeep_aiohttp.py
+++ b/onvif/zeep_aiohttp.py
@@ -161,8 +161,6 @@ class AIOHTTPTransport(Transport):
                 response.status,
                 content,
             )
-
-            return response, content
         except RuntimeError as exc:
             # Handle RuntimeError which may occur if the session is closed
             msg = f"Failed to post to {address}: {exc}"
@@ -170,6 +168,8 @@ class AIOHTTPTransport(Transport):
         except TimeoutError as exc:
             msg = f"Request to {address} timed out"
             raise TimeoutError(msg) from exc
+        else:
+            return response, content
 
     async def post(
         self, address: str, message: str, headers: dict[str, str]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ extend-select = [
   "SIM", # flake8-simplify
   "T20", # flake8-print
   "TC", # flake8-type-checking
+  "TRY", # tryceratops
 ]
 ignore = [
   "PLR0911", # too many return statements
@@ -28,6 +29,7 @@ ignore = [
   "PLR0915", # too many statements
   "PLR2004", # magic value used in comparison
   "PLW2901", # loop variable overwritten
+  "TRY003", # long messages outside exception class
   # Re-enable once the rules these noqa directives reference (A, F841) are
   # selected; until then RUF100 would force deleting noqa comments we'll need
   # back.


### PR DESCRIPTION
## Summary

Eleventh slice off #190; enables TRY so exception-handling anti-patterns get caught at lint time.

The real wins are TRY400 (preserves tracebacks in logs by using logger.exception) and TRY300 (narrows the try block so only the actually-raising calls live under it). TRY003 (long messages outside the exception class) is ignored as a project preference.

## Changes

- `pyproject.toml`: extend-select adds `TRY`; ignore adds `TRY003`.
- `onvif/zeep_aiohttp.py`: `AIOHTTPTransport._post` moves the success-path `return response, content` into an `else` block (TRY300).
- `onvif/managers.py`: `BaseManager._process_pull_message` swaps `logger.error` for `logger.exception` inside an except handler so the XML parse traceback ends up in the log (TRY400).

## Test plan

- `ruff check` clean
- `ruff format --check` clean
- `pytest tests/` 180 passed