### PR TITLE
ci: enable ruff flake8-async (ASYNC) rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ target-version = "py310"
 
 [tool.ruff.lint]
 extend-select = [
+  "ASYNC", # flake8-async
   "B", # flake8-bugbear
   "DTZ", # flake8-datetimez
   "EM", # flake8-errmsg


### PR DESCRIPTION
## Summary

Twelfth slice off #190; enables ASYNC as defensive guard rails for an async library.

The rule group catches blocking IO inside coroutines, sync sleep in async loops, and trio / anyio misuse before they land. Zero current violations so this is purely future-proofing.

## Changes

- `pyproject.toml`: extend-select adds `ASYNC`. No source changes needed.

## Test plan

- `ruff check` clean
- `ruff format --check` clean
- `pytest tests/` 183 passed