### PR TITLE
ci: enable ruff flake8-return (RET) rules

### DIFF
--- a/onvif/client.py
+++ b/onvif/client.py
@@ -894,15 +894,14 @@ class ONVIFCamera:
         if existing_service:
             if existing_service.xaddr == xaddr:
                 return existing_service
-            else:
-                # Close the existing service since it's no longer valid.
-                # This can happen when a new PullPointSubscription is created.
-                logger.debug(
-                    "Closing service %s with %s", binding_key, existing_service.xaddr
-                )
-                # Hold a reference to the task so it doesn't get
-                # garbage collected before it completes.
-                await existing_service.close()
+            # Close the existing service since it's no longer valid.
+            # This can happen when a new PullPointSubscription is created.
+            logger.debug(
+                "Closing service %s with %s", binding_key, existing_service.xaddr
+            )
+            # Hold a reference to the task so it doesn't get
+            # garbage collected before it completes.
+            await existing_service.close()
             self.services.pop(binding_key)
 
         logger.debug("Creating service %s with %s", binding_key, xaddr)

--- a/onvif/managers.py
+++ b/onvif/managers.py
@@ -269,7 +269,7 @@ class NotificationManager(BaseManager):
         """Process a notification message."""
         if not self._operation:
             logger.debug("%s: Notifications not setup", self._device.host)
-            return
+            return None
         try:
             envelope = parse_xml(
                 content,  # type: ignore[arg-type]

--- a/onvif/wrappers.py
+++ b/onvif/wrappers.py
@@ -37,7 +37,7 @@ def retry_connection_error(
         we need to retry the operation.
         """
 
-        async def _async_wrap_connection_error_retry(  # type: ignore[return]
+        async def _async_wrap_connection_error_retry(  # type: ignore[return]  # noqa: RET503
             *args: P.args, **kwargs: P.kwargs
         ) -> T:
             logger.debug(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ extend-select = [
   "EM", # flake8-errmsg
   "I", # isort
   "PL", # pylint
+  "RET", # flake8-return
   "RUF", # ruff-specific
   "S", # flake8-bandit
   "SIM", # flake8-simplify


### PR DESCRIPTION
## Summary

Thirteenth slice off #190; enables RET so return-statement style stays consistent.

## Changes

- `pyproject.toml`: extend-select adds `RET`.
- `onvif/client.py`: drop the unnecessary else after a return in `ONVIFCamera._update_or_create_service` (RET505).
- `onvif/managers.py`: make the early-out return from `NotificationManager.process` explicit with `return None` (RET502).
- `onvif/wrappers.py`: the retry decorator's inner coroutine has an unreachable path past the loop (the last attempt always raises); the existing `# type: ignore[return]` is extended with `# noqa: RET503` so the explicit-return rule does not flag this intentional shape.

## Test plan

- `ruff check` clean
- `ruff format --check` clean
- `pytest tests/` 183 passed