### PR TITLE
ci: enable ruff Perflint (PERF) rules

### DIFF
--- a/onvif/wrappers.py
+++ b/onvif/wrappers.py
@@ -52,7 +52,7 @@ def retry_connection_error(
                         "Attempt %s/%s for %s", attempt + 1, attempts, func.__name__
                     )
                     return await func(*args, **kwargs)
-                except exception as ex:
+                except exception as ex:  # noqa: PERF203
                     #
                     # We should only need to retry on ServerDisconnectedError but some cameras
                     # are flakey and sometimes do not respond to the Renew request so we

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ extend-select = [
   "DTZ", # flake8-datetimez
   "EM", # flake8-errmsg
   "I", # isort
+  "PERF", # Perflint
   "PL", # pylint
   "RET", # flake8-return
   "RUF", # ruff-specific


### PR DESCRIPTION
## Summary

Fourteenth slice off #190; enables PERF so future hot-path perf anti-patterns surface at lint time.

Only current violation is PERF203 in the retry decorator; the try / except inside the loop is exactly the retry semantics, so it gets a targeted noqa.

## Changes

- `pyproject.toml`: extend-select adds `PERF`.
- `onvif/wrappers.py`: `# noqa: PERF203` on the except clause inside `retry_connection_error`'s inner loop.

## Test plan

- `ruff check` clean
- `ruff format --check` clean
- `pytest tests/` 195 passed