### PR TITLE
Share SqliteCache lazily off the event loop; pre-warm bundled wsdl dir

### DIFF
--- a/onvif/client.py
+++ b/onvif/client.py
@@ -72,6 +72,26 @@ def _list_wsdl_dir(wsdl_dir: str) -> frozenset[str] | None:
         return None
 
 
+# Pre-warm the bundled wsdl directory at module import time, before any event
+# loop is running, so direct ONVIFService(...) usage in async code with a
+# bundled wsdl path does not trip blockbuster on the first existence check.
+_BUNDLED_WSDL_PATH = os.path.join(os.path.dirname(__file__), "wsdl")
+_WSDL_DIR_FILES[_BUNDLED_WSDL_PATH] = _list_wsdl_dir(_BUNDLED_WSDL_PATH)
+
+
+# SqliteCache opens its sqlite file in __init__, which does blocking I/O.
+# Build one shared instance lazily off the event loop and reuse it across all
+# ONVIFService transports so the per-service setup() stays non-blocking.
+_SHARED_SQLITE_CACHE: SqliteCache | None = None
+
+
+async def _get_shared_sqlite_cache() -> SqliteCache:
+    global _SHARED_SQLITE_CACHE  # noqa: PLW0603
+    if _SHARED_SQLITE_CACHE is None:
+        _SHARED_SQLITE_CACHE = await asyncio.to_thread(SqliteCache)
+    return _SHARED_SQLITE_CACHE
+
+
 _DEFAULT_TIMEOUT = 90
 _PULLPOINT_TIMEOUT = 90
 _CONNECT_TIMEOUT = 30
@@ -335,10 +355,14 @@ class ONVIFService:
         # allows the server to close the connection at any time, and cameras
         # routinely do so between event polls. The cache only affects WSDL
         # loading, so it is orthogonal to the connection-error retry.
+        # The SqliteCache opens a sqlite file in its constructor (blocking I/O);
+        # leave cache=None here and let setup() attach the shared cache instance
+        # built off the event loop.
+        self._no_cache = no_cache
         self.transport = AsyncTransportProtocolErrorHandler(
             session=self._session,
             verify_ssl=False,
-            cache=None if no_cache else SqliteCache(),
+            cache=None,
         )
         self.document: Document | None = None
         self.zeep_client_authless: ZeepAsyncClient | None = None
@@ -355,6 +379,8 @@ class ONVIFService:
         wsse = UsernameDigestTokenDtDiff(
             self.user, self.passwd, dt_diff=self.dt_diff, use_digest=self.encrypt
         )
+        if not self._no_cache and self.transport.cache is None:
+            self.transport.cache = await _get_shared_sqlite_cache()
         self.document = await _cached_document(self.url)
         self.zeep_client_authless = ZeepAsyncClient(
             wsdl=self.document,

--- a/onvif/client.py
+++ b/onvif/client.py
@@ -86,22 +86,27 @@ _WSDL_DIR_FILES[_WSDL_PATH] = _list_wsdl_dir(_WSDL_PATH)
 
 # SqliteCache opens its sqlite file in __init__, which does blocking I/O.
 # Build one shared instance lazily off the event loop and reuse it across all
-# ONVIFService transports so the per-service setup() stays non-blocking. An
-# asyncio.Lock guards concurrent setup() calls so exactly one cache is built.
+# ONVIFService transports so the per-service setup() stays non-blocking. The
+# Lock is created lazily on first use (we cannot promise a running loop at
+# import time) and double-checked, so concurrent first-touch setup() calls
+# (for example, multiple cameras configured in parallel at startup) build
+# exactly one SqliteCache instead of racing through to_thread() twice. The
+# pre-Lock check-and-create is race-free because asyncio coroutines are
+# cooperatively scheduled within a single loop and there is no await between
+# the None check and the assignment.
 _SHARED_SQLITE_CACHE: SqliteCache | None = None
 _SHARED_SQLITE_CACHE_LOCK: asyncio.Lock | None = None
 
 
 async def _get_shared_sqlite_cache() -> SqliteCache:
     global _SHARED_SQLITE_CACHE, _SHARED_SQLITE_CACHE_LOCK  # noqa: PLW0603
-    if _SHARED_SQLITE_CACHE is not None:
-        return _SHARED_SQLITE_CACHE
-    if _SHARED_SQLITE_CACHE_LOCK is None:
-        _SHARED_SQLITE_CACHE_LOCK = asyncio.Lock()
-    async with _SHARED_SQLITE_CACHE_LOCK:
-        if _SHARED_SQLITE_CACHE is None:
-            _SHARED_SQLITE_CACHE = await asyncio.to_thread(SqliteCache)
-        return _SHARED_SQLITE_CACHE
+    if _SHARED_SQLITE_CACHE is None:
+        if _SHARED_SQLITE_CACHE_LOCK is None:
+            _SHARED_SQLITE_CACHE_LOCK = asyncio.Lock()
+        async with _SHARED_SQLITE_CACHE_LOCK:
+            if _SHARED_SQLITE_CACHE is None:
+                _SHARED_SQLITE_CACHE = await asyncio.to_thread(SqliteCache)
+    return _SHARED_SQLITE_CACHE
 
 
 _DEFAULT_TIMEOUT = 90

--- a/onvif/client.py
+++ b/onvif/client.py
@@ -48,7 +48,10 @@ logging.basicConfig(level=logging.INFO)
 logging.getLogger("zeep.client").setLevel(logging.CRITICAL)
 
 _SENTINEL = object()
-_WSDL_PATH = os.path.join(os.path.dirname(os.path.dirname(__file__)), "wsdl")
+# Default wsdl_dir for ONVIFCamera. Points at the WSDL files bundled with the
+# package (onvif/wsdl); historically this was off by one level and pointed at a
+# directory that did not exist, which silently forced every caller to override.
+_WSDL_PATH = os.path.join(os.path.dirname(__file__), "wsdl")
 # Names of regular files in each wsdl_dir, populated lazily off the event loop
 # on first use so the directory scan stays out of the asyncio path. None means
 # the cache could not be built and callers should fall back to path_isfile.
@@ -72,24 +75,33 @@ def _list_wsdl_dir(wsdl_dir: str) -> frozenset[str] | None:
         return None
 
 
-# Pre-warm the bundled wsdl directory at module import time, before any event
-# loop is running, so direct ONVIFService(...) usage in async code with a
-# bundled wsdl path does not trip blockbuster on the first existence check.
-_BUNDLED_WSDL_PATH = os.path.join(os.path.dirname(__file__), "wsdl")
-_WSDL_DIR_FILES[_BUNDLED_WSDL_PATH] = _list_wsdl_dir(_BUNDLED_WSDL_PATH)
+# Pre-warm the bundled wsdl directory at module import time so direct
+# ONVIFService(...) usage in async code with a bundled wsdl path does not trip
+# blockbuster on the first existence check. Import normally happens at startup
+# before any event loop is running; if onvif.client is imported from inside a
+# running loop, the alternative (lazy warm on first direct use) would block in
+# the loop too, so accept the one-shot scandir here.
+_WSDL_DIR_FILES[_WSDL_PATH] = _list_wsdl_dir(_WSDL_PATH)
 
 
 # SqliteCache opens its sqlite file in __init__, which does blocking I/O.
 # Build one shared instance lazily off the event loop and reuse it across all
-# ONVIFService transports so the per-service setup() stays non-blocking.
+# ONVIFService transports so the per-service setup() stays non-blocking. An
+# asyncio.Lock guards concurrent setup() calls so exactly one cache is built.
 _SHARED_SQLITE_CACHE: SqliteCache | None = None
+_SHARED_SQLITE_CACHE_LOCK: asyncio.Lock | None = None
 
 
 async def _get_shared_sqlite_cache() -> SqliteCache:
-    global _SHARED_SQLITE_CACHE  # noqa: PLW0603
-    if _SHARED_SQLITE_CACHE is None:
-        _SHARED_SQLITE_CACHE = await asyncio.to_thread(SqliteCache)
-    return _SHARED_SQLITE_CACHE
+    global _SHARED_SQLITE_CACHE, _SHARED_SQLITE_CACHE_LOCK  # noqa: PLW0603
+    if _SHARED_SQLITE_CACHE is not None:
+        return _SHARED_SQLITE_CACHE
+    if _SHARED_SQLITE_CACHE_LOCK is None:
+        _SHARED_SQLITE_CACHE_LOCK = asyncio.Lock()
+    async with _SHARED_SQLITE_CACHE_LOCK:
+        if _SHARED_SQLITE_CACHE is None:
+            _SHARED_SQLITE_CACHE = await asyncio.to_thread(SqliteCache)
+        return _SHARED_SQLITE_CACHE
 
 
 _DEFAULT_TIMEOUT = 90

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+import onvif.client
 from onvif.client import _WSDL_DIR_FILES
 
 try:
@@ -39,19 +40,22 @@ def pytest_collection_modifyitems(
 
 
 @pytest.fixture(autouse=True)
-def _reset_wsdl_dir_cache() -> Iterator[None]:
-    """Snapshot _WSDL_DIR_FILES so each test starts from the import-time state.
+def _reset_onvif_client_caches() -> Iterator[None]:
+    """Snapshot module-level caches so each test starts from a known state.
 
-    The bundled wsdl directory is pre-warmed at module import; tests must not
-    leak entries (for example, tmp_path scratch dirs) into other tests, and
-    must not delete the bundled entry that subsequent tests rely on.
+    _WSDL_DIR_FILES is pre-warmed at import for the bundled wsdl directory;
+    tests must not leak tmp_path entries into other tests nor drop the bundled
+    entry. _SHARED_SQLITE_CACHE is lazily built on first setup() call; reset to
+    None so a test cannot observe a cache left behind by an earlier test.
     """
-    snapshot = dict(_WSDL_DIR_FILES)
+    wsdl_snapshot = dict(_WSDL_DIR_FILES)
+    sqlite_snapshot = onvif.client._SHARED_SQLITE_CACHE
     try:
         yield
     finally:
         _WSDL_DIR_FILES.clear()
-        _WSDL_DIR_FILES.update(snapshot)
+        _WSDL_DIR_FILES.update(wsdl_snapshot)
+        onvif.client._SHARED_SQLITE_CACHE = sqlite_snapshot
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,8 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from onvif.client import _WSDL_DIR_FILES
+
 try:
     from blockbuster import BlockBuster, blockbuster_ctx
 except ImportError:
@@ -17,9 +19,6 @@ if TYPE_CHECKING:
 _KNOWN_BLOCKING: frozenset[str] = frozenset(
     {
         "tests/test_server_disconnected_retry.py::test_multiple_sequential_requests_with_disconnects",
-        "tests/test_server_disconnected_retry.py::test_onvif_service_retries_on_server_disconnect[False]",
-        "tests/test_types.py::test_parse_invalid_dt",
-        "tests/test_util.py::test_normalize_url_with_missing_url",
     }
 )
 
@@ -37,6 +36,22 @@ def pytest_collection_modifyitems(
     for item in items:
         if item.nodeid in _KNOWN_BLOCKING:
             item.add_marker(marker)
+
+
+@pytest.fixture(autouse=True)
+def _reset_wsdl_dir_cache() -> Iterator[None]:
+    """Snapshot _WSDL_DIR_FILES so each test starts from the import-time state.
+
+    The bundled wsdl directory is pre-warmed at module import; tests must not
+    leak entries (for example, tmp_path scratch dirs) into other tests, and
+    must not delete the bundled entry that subsequent tests rely on.
+    """
+    snapshot = dict(_WSDL_DIR_FILES)
+    try:
+        yield
+    finally:
+        _WSDL_DIR_FILES.clear()
+        _WSDL_DIR_FILES.update(snapshot)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,17 +45,21 @@ def _reset_onvif_client_caches() -> Iterator[None]:
 
     _WSDL_DIR_FILES is pre-warmed at import for the bundled wsdl directory;
     tests must not leak tmp_path entries into other tests nor drop the bundled
-    entry. _SHARED_SQLITE_CACHE is lazily built on first setup() call; reset to
-    None so a test cannot observe a cache left behind by an earlier test.
+    entry. _SHARED_SQLITE_CACHE is lazily built on first setup() call and
+    _SHARED_SQLITE_CACHE_LOCK binds to the running event loop on first acquire,
+    so reset both between tests; otherwise the lock would carry into the next
+    test still attached to the previous, closed loop.
     """
     wsdl_snapshot = dict(_WSDL_DIR_FILES)
     sqlite_snapshot = onvif.client._SHARED_SQLITE_CACHE
+    lock_snapshot = onvif.client._SHARED_SQLITE_CACHE_LOCK
     try:
         yield
     finally:
         _WSDL_DIR_FILES.clear()
         _WSDL_DIR_FILES.update(wsdl_snapshot)
         onvif.client._SHARED_SQLITE_CACHE = sqlite_snapshot
+        onvif.client._SHARED_SQLITE_CACHE_LOCK = lock_snapshot
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -22,6 +22,7 @@ import onvif.client
 from onvif import ONVIFCamera
 from onvif.client import (
     _WSDL_DIR_FILES,
+    _WSDL_PATH,
     ONVIFService,
     ZeepAsyncClient,
     _get_shared_sqlite_cache,
@@ -57,6 +58,13 @@ async def create_test_camera(
 # --------------------------------------------------------------------------
 # _list_wsdl_dir
 # --------------------------------------------------------------------------
+
+
+def test_bundled_wsdl_dir_is_prewarmed_at_import() -> None:
+    """Import-time pre-warm populates _WSDL_DIR_FILES for the bundled wsdl dir."""
+    cached = _WSDL_DIR_FILES.get(_WSDL_PATH)
+    assert cached is not None
+    assert "devicemgmt.wsdl" in cached
 
 
 def test_list_wsdl_dir_returns_regular_files() -> None:
@@ -129,6 +137,63 @@ def test_onvif_service_missing_wsdl_raises() -> None:
             "password",
             "/nonexistent/does-not-exist.wsdl",
         )
+
+
+@pytest.mark.asyncio
+async def test_setup_attaches_shared_sqlite_cache_when_caching() -> None:
+    """Two services with no_cache=False end up pointing at the same cache.
+
+    Aborts setup() right after the cache assignment so the test does not need
+    to mock the rest of zeep's binding/namespace plumbing.
+    """
+    wsdl = os.path.join(_REAL_WSDL_DIR, "devicemgmt.wsdl")
+    fake_cache = Mock()
+    stop = RuntimeError("stop after cache assignment")
+
+    service_a = ONVIFService("http://a/", "u", "p", wsdl, no_cache=False)
+    service_b = ONVIFService("http://b/", "u", "p", wsdl, no_cache=False)
+    try:
+        assert service_a.transport.cache is None
+        assert service_b.transport.cache is None
+
+        with (
+            patch(
+                "onvif.client._get_shared_sqlite_cache",
+                new=AsyncMock(return_value=fake_cache),
+            ),
+            patch("onvif.client._cached_document", new=AsyncMock(side_effect=stop)),
+        ):
+            with pytest.raises(RuntimeError):
+                await service_a.setup()
+            with pytest.raises(RuntimeError):
+                await service_b.setup()
+
+        assert service_a.transport.cache is fake_cache
+        assert service_b.transport.cache is fake_cache
+    finally:
+        await service_a.close()
+        await service_b.close()
+
+
+@pytest.mark.asyncio
+async def test_setup_leaves_cache_none_when_no_cache_is_true() -> None:
+    """no_cache=True must not pull in the shared SqliteCache during setup()."""
+    wsdl = os.path.join(_REAL_WSDL_DIR, "devicemgmt.wsdl")
+    stop = RuntimeError("stop after cache check")
+    service = ONVIFService("http://a/", "u", "p", wsdl, no_cache=True)
+    try:
+        get_cache = AsyncMock()
+        with (
+            patch("onvif.client._get_shared_sqlite_cache", new=get_cache),
+            patch("onvif.client._cached_document", new=AsyncMock(side_effect=stop)),
+            pytest.raises(RuntimeError),
+        ):
+            await service.setup()
+
+        assert service.transport.cache is None
+        get_cache.assert_not_called()
+    finally:
+        await service.close()
 
 
 def test_service_wrapper_falls_back_to_positional_args() -> None:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -20,7 +20,7 @@ import pytest
 
 import onvif.client
 from onvif import ONVIFCamera
-from onvif.client import ONVIFService, ZeepAsyncClient, _list_wsdl_dir
+from onvif.client import _WSDL_DIR_FILES, ONVIFService, ZeepAsyncClient, _list_wsdl_dir
 from onvif.exceptions import ONVIFError
 
 if TYPE_CHECKING:
@@ -359,6 +359,30 @@ def test_get_definition_unsupported_service_without_xaddr() -> None:
 # --------------------------------------------------------------------------
 # ONVIFCamera.create_onvif_service
 # --------------------------------------------------------------------------
+
+
+@pytest.fixture
+def _wsdl_scratch_dir(tmp_path):
+    """A scratch wsdl_dir prepared synchronously so async tests can use it."""
+    (tmp_path / "devicemgmt.wsdl").write_text("<wsdl/>")
+    return tmp_path
+
+
+@pytest.mark.asyncio
+async def test_create_onvif_service_warms_wsdl_dir_cache(_wsdl_scratch_dir) -> None:
+    """A previously unseen wsdl_dir is scanned off the event loop on first use."""
+    wsdl_dir = str(_wsdl_scratch_dir)
+    assert wsdl_dir not in _WSDL_DIR_FILES
+
+    async with create_test_camera(wsdl_dir=wsdl_dir) as cam:
+        sentinel = Mock(spec=ONVIFService)
+        sentinel.setup = AsyncMock()
+        with patch("onvif.client.ONVIFService", return_value=sentinel):
+            await cam.create_onvif_service("devicemgmt")
+
+    cached = _WSDL_DIR_FILES.get(wsdl_dir)
+    assert cached is not None
+    assert "devicemgmt.wsdl" in cached
 
 
 @pytest.mark.asyncio

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -20,7 +20,13 @@ import pytest
 
 import onvif.client
 from onvif import ONVIFCamera
-from onvif.client import _WSDL_DIR_FILES, ONVIFService, ZeepAsyncClient, _list_wsdl_dir
+from onvif.client import (
+    _WSDL_DIR_FILES,
+    ONVIFService,
+    ZeepAsyncClient,
+    _get_shared_sqlite_cache,
+    _list_wsdl_dir,
+)
 from onvif.exceptions import ONVIFError
 
 if TYPE_CHECKING:
@@ -75,6 +81,23 @@ def test_list_wsdl_dir_unreadable_returns_none(tmp_path) -> None:
 
     with patch("onvif.client.os.scandir", _raise_permission):
         assert _list_wsdl_dir(str(tmp_path)) is None
+
+
+# --------------------------------------------------------------------------
+# _get_shared_sqlite_cache
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_shared_sqlite_cache_is_singleton() -> None:
+    """Repeat calls return the same instance without rebuilding the cache."""
+    with patch("onvif.client.SqliteCache") as cache_cls:
+        cache_cls.return_value = Mock()
+        first = await _get_shared_sqlite_cache()
+        second = await _get_shared_sqlite_cache()
+
+    assert first is second
+    assert cache_cls.call_count == 1
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
Follow up to #206. Three of the four tests still flagged blocking under blockbuster all created a fresh SqliteCache in ONVIFService.__init__; sqlite opens the on-disk file synchronously. Defer to a single shared SqliteCache built via asyncio.to_thread in setup(); all services point at the same on-disk file already, so sharing the Python wrapper just avoids redundant connections.

Also pre-warm _WSDL_DIR_FILES for the bundled wsdl directory at module import time so direct ONVIFService(...) usage in async code does not block on the first existence check; an autouse conftest fixture snapshots and restores the cache between tests.