### PR TITLE
ci: enable ruff flake8-pyi (PYI) rules

### DIFF
--- a/onvif/zeep_aiohttp.py
+++ b/onvif/zeep_aiohttp.py
@@ -15,6 +15,8 @@ from zeep.utils import get_version
 from zeep.wsdl.utils import etree_to_string
 
 if TYPE_CHECKING:
+    from types import TracebackType
+
     from lxml.etree import _Element
     from multidict import CIMultiDict
     from zeep.cache import SqliteCache
@@ -56,11 +58,16 @@ class AIOHTTPTransport(Transport):
         # Extract timeout from session
         self._client_timeout = session.timeout
 
-    async def __aenter__(self) -> AIOHTTPTransport:
+    async def __aenter__(self) -> AIOHTTPTransport:  # noqa: PYI034
         """Enter async context."""
         return self
 
-    async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
         """Exit async context."""
 
     async def aclose(self) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ extend-select = [
   "I", # isort
   "PERF", # Perflint
   "PL", # pylint
+  "PYI", # flake8-pyi
   "RET", # flake8-return
   "RUF", # ruff-specific
   "S", # flake8-bandit


### PR DESCRIPTION
## Summary

Fifteenth slice off #190; enables PYI so the context-manager protocol is properly typed.

PYI036 is the substantive part; PYI034 picks up a targeted noqa because Python 3.10 cannot import Self from typing without a typing_extensions dependency, and the current class-name return shape works fine.

## Changes

- `pyproject.toml`: extend-select adds `PYI`.
- `onvif/zeep_aiohttp.py`: `AIOHTTPTransport.__aexit__` is now annotated as `type[BaseException] | None / BaseException | None / TracebackType | None` (PYI036); `__aenter__` keeps its class-name return type with a `# noqa: PYI034`.
- `TracebackType` is imported under `TYPE_CHECKING`.

## Test plan

- `ruff check` clean
- `ruff format --check` clean
- `pytest tests/` 195 passed