### PR TITLE
ci: enable ruff flake8-logging-format (G) rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ extend-select = [
   "B", # flake8-bugbear
   "DTZ", # flake8-datetimez
   "EM", # flake8-errmsg
+  "G", # flake8-logging-format
   "I", # isort
   "PERF", # Perflint
   "PL", # pylint


### PR DESCRIPTION
## Summary

Sixteenth slice off #190; enables G so logging calls stay on lazy %-formatting instead of f-strings (which eagerly evaluate even when the log level is suppressed).

For a library that logs per request, lazy formatting matters; this rule prevents future regressions. Zero current violations.

## Changes

- `pyproject.toml`: extend-select adds `G`. No source changes.

## Test plan

- `ruff check` clean
- `ruff format --check` clean
- `pytest tests/` 195 passed