### PR TITLE
ci: enable ruff pyupgrade (UP) rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ extend-select = [
   "T20", # flake8-print
   "TC", # flake8-type-checking
   "TRY", # tryceratops
+  "UP", # pyupgrade
 ]
 ignore = [
   "PLR0911", # too many return statements


### PR DESCRIPTION
## Summary

Seventeenth slice off #190; enables UP at the ruff layer to complement the pre-commit pyupgrade hook.

Selecting UP in ruff means the same modernization rules apply when contributors run ruff directly or when CI bypasses pre-commit. Zero current violations.

## Changes

- `pyproject.toml`: extend-select adds `UP`. No source changes.

## Test plan

- `ruff check` clean
- `ruff format --check` clean
- `pytest tests/` 195 passed