### PR TITLE
ci: enable ruff flake8-pie (PIE) rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ extend-select = [
   "G", # flake8-logging-format
   "I", # isort
   "PERF", # Perflint
+  "PIE", # flake8-pie
   "PL", # pylint
   "PYI", # flake8-pyi
   "RET", # flake8-return

--- a/tests/test_server_disconnected_retry.py
+++ b/tests/test_server_disconnected_retry.py
@@ -106,7 +106,6 @@ class DisconnectingHTTPProtocol(asyncio.Protocol):
 
     def connection_lost(self, exc: Exception | None) -> None:
         """Called when the connection is lost."""
-        pass
 
 
 class DisconnectingServer:


### PR DESCRIPTION
## Summary

Eighteenth slice off #190; enables PIE so misc anti-patterns (unnecessary pass, dict/set literal shortcuts, etc.) get flagged.

## Changes

- `pyproject.toml`: extend-select adds `PIE`.
- `tests/test_server_disconnected_retry.py`: drop unnecessary `pass` from `connection_lost()`; the method already has a docstring acting as its body (PIE790).

## Test plan

- `ruff check` clean
- `ruff format --check` clean
- `pytest tests/` 195 passed