### PR TITLE
ci: enable ruff flake8-logging (LOG) rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ extend-select = [
   "EM", # flake8-errmsg
   "G", # flake8-logging-format
   "I", # isort
+  "LOG", # flake8-logging
   "PERF", # Perflint
   "PIE", # flake8-pie
   "PL", # pylint


### PR DESCRIPTION
## Summary

Nineteenth slice off #190; enables LOG so logger misuse patterns get flagged at lint time.

LOG complements G: G covers how the message is built, LOG covers how the logger itself is used (no root logger, WARN vs WARNING, exception() called outside an except, etc.). Zero current violations.

## Changes

- `pyproject.toml`: extend-select adds `LOG`. No source changes.

## Test plan

- `ruff check` clean
- `ruff format --check` clean
- `pytest tests/` 195 passed