### PR TITLE
ci: enable ruff flake8-comprehensions (C4) rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ target-version = "py310"
 extend-select = [
   "ASYNC", # flake8-async
   "B", # flake8-bugbear
+  "C4", # flake8-comprehensions
   "DTZ", # flake8-datetimez
   "EM", # flake8-errmsg
   "G", # flake8-logging-format


### PR DESCRIPTION
## Summary

Twentieth slice off #190; enables C4 as defensive lint for comprehension patterns.

Catches things like unnecessary list() around a generator, dict() with kwargs vs a dict literal, and redundant generator wrappers around already-iterable inputs. Zero current violations.

## Changes

- `pyproject.toml`: extend-select adds `C4`. No source changes.

## Test plan

- `ruff check` clean
- `ruff format --check` clean
- `pytest tests/` 195 passed