### PR TITLE
Retry on ClientConnectionResetError; tolerate mid-read RST in flake test

### DIFF
--- a/onvif/client.py
+++ b/onvif/client.py
@@ -180,12 +180,22 @@ class AsyncTransportProtocolErrorHandler(AIOHTTPTransport):
     Retry on remote protocol error.
 
     http://datatracker.ietf.org/doc/html/rfc2616#section-8.1.4 allows the server
-    # to close the connection at any time, we treat this as a normal and try again
-    # once since
+    to close the connection at any time, we treat this as normal and try again
+    once. Two flavors of "the pooled socket is dead before we wrote":
+    ServerDisconnectedError when aiohttp detects the close at request start, and
+    ClientConnectionResetError when it detects the close mid-prepare (the writer
+    raises before transport.write()). Both mean the request did not reach the
+    server, so retry is idempotency-safe; we deliberately do not catch the
+    broader ClientOSError because that can fire after bytes are on the wire.
     """
 
     @retry_connection_error(
-        attempts=2, exception=aiohttp.ServerDisconnectedError, backoff=0
+        attempts=2,
+        exception=(
+            aiohttp.ServerDisconnectedError,
+            aiohttp.ClientConnectionResetError,
+        ),
+        backoff=0,
     )
     async def post(
         self, address: str, message: str, headers: dict[str, str]
@@ -193,7 +203,12 @@ class AsyncTransportProtocolErrorHandler(AIOHTTPTransport):
         return await super().post(address, message, headers)
 
     @retry_connection_error(
-        attempts=2, exception=aiohttp.ServerDisconnectedError, backoff=0
+        attempts=2,
+        exception=(
+            aiohttp.ServerDisconnectedError,
+            aiohttp.ClientConnectionResetError,
+        ),
+        backoff=0,
     )
     async def get(
         self,
@@ -204,7 +219,12 @@ class AsyncTransportProtocolErrorHandler(AIOHTTPTransport):
         return await super().get(address, params, headers)
 
     @retry_connection_error(
-        attempts=2, exception=aiohttp.ServerDisconnectedError, backoff=0
+        attempts=2,
+        exception=(
+            aiohttp.ServerDisconnectedError,
+            aiohttp.ClientConnectionResetError,
+        ),
+        backoff=0,
     )
     async def post_xml(
         self, address: str, envelope: Any, headers: dict[str, str]

--- a/onvif/wrappers.py
+++ b/onvif/wrappers.py
@@ -20,7 +20,7 @@ logger = logging.getLogger("onvif")
 
 def retry_connection_error(
     attempts: int = DEFAULT_ATTEMPTS,
-    exception: type[Exception] = aiohttp.ClientError,
+    exception: type[Exception] | tuple[type[Exception], ...] = aiohttp.ClientError,
     backoff: float | None = None,
 ) -> Callable[[Callable[P, Awaitable[T]]], Callable[P, Awaitable[T]]]:
     """Define a wrapper to retry on connection error."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,11 +17,7 @@ if TYPE_CHECKING:
     from collections.abc import Iterator
 
 
-_KNOWN_BLOCKING: frozenset[str] = frozenset(
-    {
-        "tests/test_server_disconnected_retry.py::test_multiple_sequential_requests_with_disconnects",
-    }
-)
+_KNOWN_BLOCKING: frozenset[str] = frozenset()
 
 
 def pytest_collection_modifyitems(

--- a/tests/test_server_disconnected_retry.py
+++ b/tests/test_server_disconnected_retry.py
@@ -249,7 +249,17 @@ async def test_retry_on_server_disconnect_with_mock_server(
 async def test_multiple_sequential_requests_with_disconnects(
     disconnecting_server: tuple[DisconnectingServer, str],
 ) -> None:
-    """Test multiple sequential requests with server disconnecting each time."""
+    """Sequential requests against a server that closes after each response.
+
+    The transport retries only the pre-write disconnect cases
+    (ServerDisconnectedError, ClientConnectionResetError) because those mean
+    the request bytes never reached the server. A mid-read kernel RST
+    (ClientOSError) can still surface when the client's response read races
+    the server's close, and we deliberately do not auto-retry that case to
+    avoid double-executing non-idempotent operations. The test therefore
+    tolerates a small number of ClientOSError failures and asserts the
+    transport stays usable across the iterations.
+    """
 
     server, base_url = disconnecting_server
 
@@ -258,19 +268,25 @@ async def test_multiple_sequential_requests_with_disconnects(
             session=session, verify_ssl=False
         )
 
-        # Create simple test envelope
         envelope = etree.Element("{http://test}TestRequest")
 
-        # Make 5 sequential requests with small delays
+        successes = 0
         for _ in range(5):
-            await asyncio.sleep(0)  # Ensure previous connection is closed
-            result = await transport.post_xml(
-                f"{base_url}/onvif/device_service", envelope, {}
-            )
+            await asyncio.sleep(0)
+            try:
+                result = await transport.post_xml(
+                    f"{base_url}/onvif/device_service", envelope, {}
+                )
+            except aiohttp.ClientOSError:
+                continue
             assert result.status_code == 200
+            successes += 1
 
-        # Each request should succeed, potentially with retries
-        assert server.request_count >= 5
+        # Most iterations should succeed; the transport must stay usable even
+        # when a few mid-read RSTs surface. server.request_count covers retries
+        # too, so it can exceed the success count.
+        assert successes >= 3
+        assert server.request_count >= successes
 
 
 @pytest.mark.asyncio
@@ -368,6 +384,71 @@ async def test_post_xml_with_retry_decorator_succeeds() -> None:
     # Should be called twice (initial + retry)
     assert mock_session.post.call_count == 2
     assert result.status_code == 200
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("mock_etree_to_string")
+async def test_post_xml_retries_on_client_connection_reset() -> None:
+    """ClientConnectionResetError ('Cannot write to closing transport') is retried.
+
+    aiohttp raises this when the pooled socket is closing before any bytes
+    are written, so the request has not reached the server and a retry is
+    idempotency-safe (sibling case to ServerDisconnectedError).
+    """
+    mock_session = Mock(spec=ClientSession)
+    mock_session.timeout = Mock(total=30, sock_read=10)
+    transport = AsyncTransportProtocolErrorHandler(
+        session=mock_session, verify_ssl=False
+    )
+
+    mock_envelope = Mock()
+    mock_envelope.tag = "TestEnvelope"
+
+    mock_response = Mock()
+    mock_response.status = 200
+    mock_response.headers = {}
+    mock_response.cookies = {}
+    mock_response.charset = "utf-8"
+    mock_response.read = AsyncMock(return_value=b"<response/>")
+
+    mock_session.post = AsyncMock(
+        side_effect=[
+            aiohttp.ClientConnectionResetError("Cannot write to closing transport"),
+            mock_response,
+        ]
+    )
+
+    result = await transport.post_xml("http://example.com/onvif", mock_envelope, {})
+
+    assert mock_session.post.call_count == 2
+    assert result.status_code == 200
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("mock_etree_to_string")
+async def test_post_xml_does_not_retry_on_client_os_error() -> None:
+    """Mid-read ClientOSError is not retried because bytes already went out.
+
+    Retrying after the server may have processed the request risks duplicate
+    Subscribe calls or PullMessages losing the in-flight event batch.
+    """
+    mock_session = Mock(spec=ClientSession)
+    mock_session.timeout = Mock(total=30, sock_read=10)
+    transport = AsyncTransportProtocolErrorHandler(
+        session=mock_session, verify_ssl=False
+    )
+
+    mock_envelope = Mock()
+    mock_envelope.tag = "TestEnvelope"
+
+    mock_session.post = AsyncMock(
+        side_effect=aiohttp.ClientOSError("Connection reset by peer")
+    )
+
+    with pytest.raises(aiohttp.ClientOSError, match="Connection reset by peer"):
+        await transport.post_xml("http://example.com/onvif", mock_envelope, {})
+
+    assert mock_session.post.call_count == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
aiohttp raises ClientConnectionResetError when the pooled socket is closing before any bytes are written; this is semantically the same as ServerDisconnectedError (request never reached the server) and idempotency-safe to retry. Add it to the AsyncTransportProtocolErrorHandler retry tuple alongside SDE.

The mid-read kernel RST that surfaces as ClientOSError is deliberately not retried because bytes may already be on the wire and the server may have processed them; retrying would risk double-executing Subscribe, losing a PullMessages batch, etc.

Relax test_multiple_sequential_requests_with_disconnects to tolerate the occasional mid-read RST that the narrow retry intentionally does not cover, assert the transport stays usable across iterations, and remove the flake from _KNOWN_BLOCKING. New unit tests cover the retry on ClientConnectionResetError and the deliberate non-retry on ClientOSError.