### PR TITLE
ci: enable ruff flake8-use-pathlib (PTH) rules

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,6 +1,6 @@
 """Sphinx configuration for python-onvif-zeep-async documentation."""
 
-import os
+from pathlib import Path
 
 # -- Project information -----------------------------------------------------
 
@@ -8,8 +8,8 @@ project = "python-onvif-zeep-async"
 author = "Cherish Chen"
 copyright = "Cherish Chen"  # noqa: A001
 
-_version_path = os.path.join(os.path.dirname(__file__), "..", "onvif", "version.txt")
-with open(_version_path) as _version_file:
+_version_path = Path(__file__).parent / ".." / "onvif" / "version.txt"
+with _version_path.open(encoding="utf-8") as _version_file:
     release = _version_file.read().strip()
 version = release
 

--- a/examples/events.py
+++ b/examples/events.py
@@ -4,9 +4,9 @@ import argparse
 import asyncio
 import datetime as dt
 import logging
-import os.path
 import pprint
 import sys
+from pathlib import Path
 
 from aiohttp import web
 
@@ -36,7 +36,7 @@ async def run(args):
         args.port,
         args.username,
         args.password,
-        wsdl_dir=f"{os.path.dirname(onvif.__file__)}/wsdl/",
+        wsdl_dir=f"{Path(onvif.__file__).parent}/wsdl/",
     )
     await mycam.update_xaddrs()
 

--- a/onvif/client.py
+++ b/onvif/client.py
@@ -6,6 +6,7 @@ import asyncio
 import datetime as dt
 import logging
 import os.path
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, TypeVar
 
 import aiohttp
@@ -51,7 +52,7 @@ _SENTINEL = object()
 # Default wsdl_dir for ONVIFCamera. Points at the WSDL files bundled with the
 # package (onvif/wsdl); historically this was off by one level and pointed at a
 # directory that did not exist, which silently forced every caller to override.
-_WSDL_PATH = os.path.join(os.path.dirname(__file__), "wsdl")
+_WSDL_PATH = str(Path(__file__).parent / "wsdl")
 # Names of regular files in each wsdl_dir, populated lazily off the event loop
 # on first use so the directory scan stays out of the asyncio path. None means
 # the cache could not be built and callers should fall back to path_isfile.
@@ -900,7 +901,7 @@ class ONVIFCamera:
         if port_type:
             namespace += "/" + port_type
 
-        wsdlpath = os.path.join(self.wsdl_dir, wsdl_file)
+        wsdlpath = str(Path(self.wsdl_dir) / wsdl_file)
         cached_files = _WSDL_DIR_FILES.get(self.wsdl_dir)
         exists = (
             wsdl_file in cached_files

--- a/onvif/transport.py
+++ b/onvif/transport.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import os.path
+from pathlib import Path
 
 from zeep.transports import Transport
 
@@ -17,7 +17,7 @@ class AsyncSafeTransport(Transport):
         if not path_isfile(url):
             msg = f"Loading {url} is not supported in async mode"
             raise RuntimeError(msg)
-        with open(os.path.expanduser(url), "rb") as fh:
+        with Path(url).expanduser().open("rb") as fh:
             return fh.read()
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ extend-select = [
   "PIE", # flake8-pie
   "PL", # pylint
   "PT", # flake8-pytest-style
+  "PTH", # flake8-use-pathlib
   "PYI", # flake8-pyi
   "Q", # flake8-quotes
   "RET", # flake8-return

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,14 @@
 """Package Setup."""
 
-import os
+from pathlib import Path
 
 from setuptools import find_packages, setup
 
-here = os.path.abspath(os.path.dirname(__file__))
-version_path = os.path.join(here, "onvif/version.txt")
-with open(version_path) as version_file:
+here = Path(__file__).parent.resolve()
+version_path = here / "onvif" / "version.txt"
+with version_path.open(encoding="utf-8") as version_file:
     version = version_file.read().strip()
-with open("README.rst") as readme_file:
+with Path("README.rst").open(encoding="utf-8") as readme_file:
     long_description = readme_file.read()
 
 requires = [

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -11,8 +11,8 @@ loading. The zeep/aiohttp dependencies they delegate to are mocked.
 from __future__ import annotations
 
 import datetime as dt
-import os
 from contextlib import asynccontextmanager
+from pathlib import Path
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -32,12 +32,11 @@ from onvif.exceptions import ONVIFError
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator
-    from pathlib import Path
 
 # The bundled WSDL files live under onvif/wsdl, not the default _WSDL_PATH
 # (which points one level above the package). Resolve the real directory so the
 # get_definition() tests can exercise the on-disk path checks.
-_REAL_WSDL_DIR = os.path.join(os.path.dirname(onvif.client.__file__), "wsdl")
+_REAL_WSDL_DIR = str(Path(onvif.client.__file__).parent / "wsdl")
 
 
 @asynccontextmanager
@@ -147,7 +146,7 @@ async def test_setup_attaches_shared_sqlite_cache_when_caching() -> None:
     Aborts setup() right after the cache assignment so the test does not need
     to mock the rest of zeep's binding/namespace plumbing.
     """
-    wsdl = os.path.join(_REAL_WSDL_DIR, "devicemgmt.wsdl")
+    wsdl = str(Path(_REAL_WSDL_DIR) / "devicemgmt.wsdl")
     fake_cache = Mock()
     stop = RuntimeError("stop after cache assignment")
 
@@ -179,7 +178,7 @@ async def test_setup_attaches_shared_sqlite_cache_when_caching() -> None:
 @pytest.mark.asyncio
 async def test_setup_leaves_cache_none_when_no_cache_is_true() -> None:
     """no_cache=True must not pull in the shared SqliteCache during setup()."""
-    wsdl = os.path.join(_REAL_WSDL_DIR, "devicemgmt.wsdl")
+    wsdl = str(Path(_REAL_WSDL_DIR) / "devicemgmt.wsdl")
     stop = RuntimeError("stop after cache check")
     service = ONVIFService("http://a/", "u", "p", wsdl, no_cache=True)
     try:

--- a/tests/test_hikvision_e2e.py
+++ b/tests/test_hikvision_e2e.py
@@ -10,7 +10,7 @@ Hikvision IP camera. They are deliberately "end to end": nothing inside
 from __future__ import annotations
 
 import datetime as dt
-import os
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
@@ -25,7 +25,7 @@ from onvif import ONVIFCamera
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator
 
-WSDL_DIR = os.path.join(os.path.dirname(onvif.__file__), "wsdl")
+WSDL_DIR = str(Path(onvif.__file__).parent / "wsdl")
 DIGEST_TYPE = (
     "http://docs.oasis-open.org/wss/2004/01/"
     "oasis-200401-wss-username-token-profile-1.0#PasswordDigest"

--- a/tests/test_server_disconnected_retry.py
+++ b/tests/test_server_disconnected_retry.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import inspect
-import os
+from pathlib import Path
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
@@ -625,7 +625,7 @@ async def test_onvif_service_retries_on_server_disconnect(no_cache: bool) -> Non
     ServerDisconnectedError surfaced to event listeners (PullMessages) instead
     of being retried as it was on the previous httpx-based release.
     """
-    wsdl = os.path.join(os.path.dirname(onvif.__file__), "wsdl", "devicemgmt.wsdl")
+    wsdl = str(Path(onvif.__file__).parent / "wsdl" / "devicemgmt.wsdl")
     service = ONVIFService(
         "http://example.com/onvif/device_service",
         "user",

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import datetime
-import os
+from pathlib import Path
 
 import pytest
 from zeep.loader import parse_xml
@@ -12,7 +12,7 @@ from onvif.transport import ASYNC_TRANSPORT
 from onvif.types import FastDateTime, ForgivingTime
 
 INVALID_TERM_TIME = b'<?xml version="1.0" encoding="UTF-8"?>\r\n<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://www.w3.org/2003/05/soap-envelope" xmlns:SOAP-ENC="http://www.w3.org/2003/05/soap-encoding" xmlns:tev="http://www.onvif.org/ver10/events/wsdl" xmlns:wsnt="http://docs.oasis-open.org/wsn/b-2" xmlns:wsa5="http://www.w3.org/2005/08/addressing" xmlns:chan="http://schemas.microsoft.com/ws/2005/02/duplex" xmlns:wsa="http://www.w3.org/2005/08/addressing" xmlns:tt="http://www.onvif.org/ver10/schema" xmlns:tns1="http://www.onvif.org/ver10/topics">\r\n<SOAP-ENV:Header>\r\n<wsa5:Action>http://www.onvif.org/ver10/events/wsdl/PullPointSubscription/PullMessagesResponse</wsa5:Action>\r\n</SOAP-ENV:Header>\r\n<SOAP-ENV:Body>\r\n<tev:PullMessagesResponse>\r\n<tev:CurrentTime>2024-08-17T00:56:16Z</tev:CurrentTime>\r\n<tev:TerminationTime>2024-08-17T00:61:16Z</tev:TerminationTime>\r\n</tev:PullMessagesResponse>\r\n</SOAP-ENV:Body>\r\n</SOAP-ENV:Envelope>\r\n'
-_WSDL_PATH = os.path.join(os.path.dirname(os.path.dirname(__file__)), "onvif", "wsdl")
+_WSDL_PATH = str(Path(__file__).parent.parent / "onvif" / "wsdl")
 
 
 @pytest.mark.asyncio

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import os
+from pathlib import Path
 
 import pytest
 from zeep.exceptions import Fault
@@ -27,7 +27,7 @@ class _Subcode:
 
 
 PULL_POINT_RESPONSE_MISSING_URL = b'<?xml version="1.0" encoding="UTF-8"?>\n<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://www.w3.org/2003/05/soap-envelope" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:wsdd="http://schemas.xmlsoap.org/ws/2005/04/discovery" xmlns:chan="http://schemas.microsoft.com/ws/2005/02/duplex" xmlns:wsa5="http://www.w3.org/2005/08/addressing" xmlns:ns1="http://www.onvif.org/ver10/pacs" xmlns:xmime="http://tempuri.org/xmime.xsd" xmlns:xop="http://www.w3.org/2004/08/xop/include" xmlns:tt="http://www.onvif.org/ver10/schema" xmlns:wsrfbf="http://docs.oasis-open.org/wsrf/bf-2" xmlns:wstop="http://docs.oasis-open.org/wsn/t-1" xmlns:wsrfr="http://docs.oasis-open.org/wsrf/r-2" xmlns:tdn="http://www.onvif.org/ver10/network/wsdl" xmlns:tds="http://www.onvif.org/ver10/device/wsdl" xmlns:tev="http://www.onvif.org/ver10/events/wsdl" xmlns:wsnt="http://docs.oasis-open.org/wsn/b-2" xmlns:timg="http://www.onvif.org/ver20/imaging/wsdl" xmlns:tmd="http://www.onvif.org/ver10/deviceIO/wsdl" xmlns:tptz="http://www.onvif.org/ver20/ptz/wsdl" xmlns:trt="http://www.onvif.org/ver10/media/wsdl" xmlns:trv="http://www.onvif.org/ver10/receiver/wsdl" xmlns:tse="http://www.onvif.org/ver10/search/wsdl"><SOAP-ENV:Header><wsa5:MessageID>urn:uuid:76acd0bc-498e-4657-9414-b386bd4b0985</wsa5:MessageID><wsa5:To SOAP-ENV:mustUnderstand="1">http://192.168.2.18:8080/onvif/device_service</wsa5:To><wsa5:Action SOAP-ENV:mustUnderstand="1">http://www.onvif.org/ver10/events/wsdl/EventPortType/CreatePullPointSubscriptionRequest</wsa5:Action></SOAP-ENV:Header><SOAP-ENV:Body><tev:CreatePullPointSubscriptionResponse><tev:SubscriptionReference><wsa5:Address/></tev:SubscriptionReference><wsnt:CurrentTime>1970-01-01T00:00:00Z</wsnt:CurrentTime><wsnt:TerminationTime>1970-01-01T00:00:00Z</wsnt:TerminationTime></tev:CreatePullPointSubscriptionResponse></SOAP-ENV:Body></SOAP-ENV:Envelope>\r\n'
-_WSDL_PATH = os.path.join(os.path.dirname(os.path.dirname(__file__)), "onvif", "wsdl")
+_WSDL_PATH = str(Path(__file__).parent.parent / "onvif" / "wsdl")
 
 
 def test_normalize_url():

--- a/tests/test_xaddrs.py
+++ b/tests/test_xaddrs.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-import os
 from contextlib import asynccontextmanager
+from pathlib import Path
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -18,7 +18,7 @@ from onvif.exceptions import ONVIFError
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator
 
-WSDL_DIR = os.path.join(os.path.dirname(onvif.__file__), "wsdl")
+WSDL_DIR = str(Path(onvif.__file__).parent / "wsdl")
 
 RECORDING_NS = "http://www.onvif.org/ver10/recording/wsdl"
 REPLAY_NS = "http://www.onvif.org/ver10/replay/wsdl"


### PR DESCRIPTION
## Summary

Enables PTH and migrates the 30 os.path.* / open() call sites flagged by it across onvif/, tests/, examples/, docs/, setup.py.

API-preserving: every site that feeds a string back to a downstream caller (wsdl_dir constants, the `get_definition` return tuple, `ONVIFService` url) wraps with `str()` so call signatures stay identical. Text-mode opens are explicit about `encoding="utf-8"`.

## Changes

- `pyproject.toml`: extend-select adds `PTH`.
- `onvif/client.py`: `_WSDL_PATH` and `wsdlpath` built via `Path` / `str(...)`.
- `onvif/transport.py`: `AsyncSafeTransport.load` uses `Path(url).expanduser().open("rb")`.
- `setup.py`: `here`, `version_path` and the `version.txt` / `README.rst` reads switched to `Path` and `Path.open(encoding="utf-8")`.
- `docs/conf.py`: same treatment for the `version.txt` read.
- `examples/events.py`: `wsdl_dir` f-string uses `Path(onvif.__file__).parent`.
- Six test files: `_REAL_WSDL_DIR`, `WSDL_DIR`, `_WSDL_PATH` constants and per-test `wsdl` joins switched to `str(Path(...) / ...)`; stray `import os` removed once unused.

## Test plan

- `ruff check` clean
- `ruff format --check` clean
- `pytest tests/` 202 passed